### PR TITLE
44 multi pipes

### DIFF
--- a/.github/sh/minishell_pipe.py
+++ b/.github/sh/minishell_pipe.py
@@ -115,9 +115,13 @@ def main():
     m_res, b_res = run_both(stdin)
     put_result(val, m_res, b_res)
 
-    stdin = "/bin/echo -e aaa\naacc\nbbb\nbbcc\nccc\naabb\nabc | /bin/grep a | /bin/grep c"
+    stdin = "/bin/echo aaa | /bin/grep a"
     m_res, b_res = run_both(stdin)
     put_result(val, m_res, b_res)
+
+    # stdin = "/bin/echo -e aaa\naacc\nbbb\nbbcc\nccc\naabb\nabc | /bin/grep a | /bin/grep c"
+    # m_res, b_res = run_both(stdin)
+    # put_result(val, m_res, b_res)
 
     # stdin = "/bin/cat | /bin/ls"
     # m_res, b_res = run_both(stdin)

--- a/.github/sh/minishell_pipe.py
+++ b/.github/sh/minishell_pipe.py
@@ -99,10 +99,6 @@ def main():
     ko = 0
     val = [test_num, ok, ko]
 
-    # stdin = None
-    # cmd = "make"
-    # run_cmd(stdin, cmd)
-
     stdin = "/bin/ls -l"
     m_res, b_res = run_both(stdin)
     put_result(val, m_res, b_res)

--- a/.github/sh/minishell_pipe.py
+++ b/.github/sh/minishell_pipe.py
@@ -1,0 +1,135 @@
+import subprocess
+
+# ----------------------------------------------------------
+# OUT_FILE = "pipe_test_out.txt"
+PATH = "./minishell"
+
+# ----------------------------------------------------------
+# color
+WHITE = "white"
+RED = "red"
+GREEN = "green"
+COLOR_DICT = {"white" : "\033[37m",
+              "red" : "\033[31m",
+              "green" : "\033[32m",
+              "end" : "\033[0m"}
+
+def print_color_str(color=WHITE, text=""):
+    print(COLOR_DICT[color] + text + COLOR_DICT["end"])
+
+def print_color_str_no_lf(color=WHITE, text=""):
+    print(COLOR_DICT[color] + text + COLOR_DICT["end"], end="")
+
+
+# ----------------------------------------------------------
+# run
+def run_cmd(stdin=None, cmd=None):
+    try:
+        res = subprocess.run(cmd, input=stdin, capture_output=True, text=True, shell=True, timeout=2)
+        return res
+    except subprocess.TimeoutExpired as e:
+        print(e.cmd)
+        # print(e.returncode)
+        # print(e.output)
+        # print(e.stdout)
+        # print(e.stderr)
+
+def run_minishell(stdin, cmd):
+    res_minishell = run_cmd(stdin, cmd)
+    if res_minishell:
+        print("=== minishell ===")
+        print(cmd, len(res_minishell.stdout), "byte")
+        print(f'[{res_minishell.stdout}]')
+        # print(res_minishell.stderr)
+        return res_minishell
+    return None
+
+def run_bash(stdin, cmd):
+    res_bash = run_cmd(stdin, cmd)
+    if res_bash:
+        print("===== bash =====")
+        print(cmd, len(res_bash.stdout), "byte")
+        print(f'[{res_bash.stdout}]')
+        # print(res_bash.stderr)
+        return res_bash
+    return None
+
+def run_both(stdin):
+    res_minishell = run_minishell(stdin, PATH)
+    res_bash = run_bash(None, stdin)
+    return res_minishell, res_bash
+
+# ----------------------------------------------------------
+# put
+def put_result(val, m_res, b_res):
+    test_num, _, _ = val
+    if m_res is None or b_res is None:
+        print_color_str(RED, f'[{test_num}. timeout]')
+        # ko
+        val[2] += 1
+    elif (m_res.stdout == b_res.stdout) and (m_res.returncode == b_res.returncode):
+        print_color_str(GREEN, f'[{test_num}. OK]')
+        # ok
+        val[1] += 1
+    else:
+        print_color_str(RED, f'[{test_num}. KO]')
+        # ko
+        val[2] += 1
+    # test_num
+    val[0] += 1
+    print()
+
+def put_total_result(val):
+    test_num, ok, ko = val
+    print()
+    print_color_str_no_lf(GREEN, "OK ")
+    print(f'{ok}, ', end="")
+    print_color_str_no_lf(RED, "KO ")
+    print(ko, end="")
+    print(f' (test case: {test_num - 1})')
+
+# ----------------------------------------------------------
+def main():
+    test_num = 1
+    ok = 0
+    ko = 0
+    val = [test_num, ok, ko]
+
+    stdin = None
+    cmd = "make"
+    run_cmd(stdin, cmd)
+
+    stdin = "/bin/ls -l"
+    m_res, b_res = run_both(stdin)
+    put_result(val, m_res, b_res)
+
+    stdin = "/bin/echo abcde"
+    m_res, b_res = run_both(stdin)
+    put_result(val, m_res, b_res)
+
+    stdin = "/bin/echo aaa bbb\n/bin/ls"
+    m_res, b_res = run_both(stdin)
+    put_result(val, m_res, b_res)
+
+    stdin = "/bin/echo aa\n/bin/echo bb\n/bin/echo ccc"
+    m_res, b_res = run_both(stdin)
+    put_result(val, m_res, b_res)
+
+    # stdin = 'echo -e "aaa\naacc\nbbb\nbbcc\nccc\naabb\nabc" | grep a | grep c'
+    # m_res, b_res = run_both(stdin)
+    # put_result(val, m_res, b_res)
+
+    # stdin = "/bin/cat | /bin/ls"
+    # m_res, b_res = run_both(stdin)
+    # put_result(val, m_res, b_res)
+
+    # stdin = "abcde"
+    # 'cat | echo -e "aaa\\naacc\\nbbb\\nbbcc\\nccc\\naabb\\nabc" | grep a | grep c'
+
+    # stdin = "aa\nbb\ncc\nbbaa\n"
+    # "cat | cat | cat | grep b"
+
+    put_total_result(val)
+
+if __name__ == '__main__':
+    main()

--- a/.github/sh/minishell_pipe.py
+++ b/.github/sh/minishell_pipe.py
@@ -87,6 +87,10 @@ def put_total_result(val):
     print_color_str_no_lf(RED, "KO ")
     print(ko, end="")
     print(f' (test case: {test_num - 1})')
+    if ok == test_num - 1:
+        exit(0)
+    else:
+        exit(1)
 
 # ----------------------------------------------------------
 def main():
@@ -95,9 +99,9 @@ def main():
     ko = 0
     val = [test_num, ok, ko]
 
-    stdin = None
-    cmd = "make"
-    run_cmd(stdin, cmd)
+    # stdin = None
+    # cmd = "make"
+    # run_cmd(stdin, cmd)
 
     stdin = "/bin/ls -l"
     m_res, b_res = run_both(stdin)

--- a/.github/sh/minishell_pipe.py
+++ b/.github/sh/minishell_pipe.py
@@ -115,9 +115,9 @@ def main():
     m_res, b_res = run_both(stdin)
     put_result(val, m_res, b_res)
 
-    # stdin = 'echo -e "aaa\naacc\nbbb\nbbcc\nccc\naabb\nabc" | grep a | grep c'
-    # m_res, b_res = run_both(stdin)
-    # put_result(val, m_res, b_res)
+    stdin = "/bin/echo -e aaa\naacc\nbbb\nbbcc\nccc\naabb\nabc | /bin/grep a | /bin/grep c"
+    m_res, b_res = run_both(stdin)
+    put_result(val, m_res, b_res)
 
     # stdin = "/bin/cat | /bin/ls"
     # m_res, b_res = run_both(stdin)

--- a/.github/workflows/minishell_pipe.yml
+++ b/.github/workflows/minishell_pipe.yml
@@ -13,8 +13,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: make
+        run: make
+
       - name: Install python3.
-        run: |
-          python3 -m pip install --upgrade pip setuptools
-      - name: Minishell multi pipes check.
+        run: python3 -m pip install --upgrade pip setuptools
+      - name: Minishell multi pipe check.
         run: python3 .github/sh/minishell_pipe.py

--- a/.github/workflows/minishell_pipe.yml
+++ b/.github/workflows/minishell_pipe.yml
@@ -1,0 +1,20 @@
+name: Minishell
+on:
+  push:
+    branches: [ "dev" ]
+  pull_request:
+    branches: [ "dev" ]
+
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install python3.
+        run: |
+          python3 -m pip install --upgrade pip setuptools
+      - name: Minishell multi pipes check.
+        run: python3 .github/sh/minishell_pipe.py

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,9 @@ DEBUG_DIR	:=	debug
 SRCS		+=	$(DEBUG_DIR)/put.c
 
 EXEC_DIR	:=	exec
-SRCS		+=	$(EXEC_DIR)/exec.c
+SRCS		+=	$(EXEC_DIR)/child_process.c \
+				$(EXEC_DIR)/exec.c \
+				$(EXEC_DIR)/parent_process.c
 
 INPUT_DIR	:=	input
 SRCS		+=	$(INPUT_DIR)/input.c

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,9 @@ MKDIR		:=	mkdir -p
 SRCS_DIR	:=	srcs
 SRCS		:=	main.c
 
+DEBUG_DIR	:=	debug
+SRCS		+=	$(DEBUG_DIR)/put.c
+
 EXEC_DIR	:=	exec
 SRCS		+=	$(EXEC_DIR)/exec.c
 

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ SRCS		+=	$(DEBUG_DIR)/put.c
 
 EXEC_DIR	:=	exec
 SRCS		+=	$(EXEC_DIR)/check_command.c \
+				$(EXEC_DIR)/child_pipes.c \
 				$(EXEC_DIR)/child_process.c \
 				$(EXEC_DIR)/exec.c \
 				$(EXEC_DIR)/parent_pipes.c \

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ sani	:
 	make re SANI=1
 
 .PHONY	: norm
-norm	:
+norm	: all
 	python3 .github/sh/norm.py
 
 
@@ -79,5 +79,9 @@ norm	:
 .PHONY	: t
 t		: re
 	./.github/sh/test.bats
+
+.PHONY	: pipe
+pipe	: all
+	python3 ./.github/sh/minishell_pipe.py
 
 -include $(DEPS)

--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,7 @@ norm	: all
 t		: re
 	./.github/sh/test.bats
 
+# test multi pipe
 .PHONY	: pipe
 pipe	: all
 	python3 ./.github/sh/minishell_pipe.py

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,8 @@ DEBUG_DIR	:=	debug
 SRCS		+=	$(DEBUG_DIR)/put.c
 
 EXEC_DIR	:=	exec
-SRCS		+=	$(EXEC_DIR)/child_process.c \
+SRCS		+=	$(EXEC_DIR)/check_command.c \
+				$(EXEC_DIR)/child_process.c \
 				$(EXEC_DIR)/exec.c \
 				$(EXEC_DIR)/parent_process.c
 

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ EXEC_DIR	:=	exec
 SRCS		+=	$(EXEC_DIR)/check_command.c \
 				$(EXEC_DIR)/child_process.c \
 				$(EXEC_DIR)/exec.c \
+				$(EXEC_DIR)/parent_pipes.c \
 				$(EXEC_DIR)/parent_process.c
 
 INPUT_DIR	:=	input

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -24,7 +24,9 @@ void	debug_func(const char *func_name, const int line_num);
 void	debug_2d_array(char **array);
 
 /* exec */
+void	child_process(char **commands, char **environ);
 int		execute_command(char **exec_command);
+int		parent_process(int *last_exit_status);
 
 /* input */
 char	*input_line(void);

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -18,14 +18,19 @@
 
 # define EXIT_MSG_NO_SUCH_FILE  "No such file or directory"
 
+typedef struct s_command {
+	char	**head;
+	char	**exec_command;
+}	t_command;
+
 // temporarily here ...
 /* debug */
 void	debug_func(const char *func_name, const int line_num);
 void	debug_2d_array(char **array);
 
 /* exec */
-void	child_process(char **commands, char **environ);
-int		execute_command(char **exec_command);
+void	child_process(t_command *commands, char **environ);
+int		execute_command(t_command *commands);
 int		parent_process(int *last_exit_status);
 
 /* input */

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -18,6 +18,11 @@
 
 # define EXIT_MSG_NO_SUCH_FILE  "No such file or directory"
 
+// temporarily here ...
+/* debug */
+void	debug_func(const char *func_name, const int line_num);
+void	debug_2d_array(char **array);
+
 /* exec */
 int		exec(char **commands);
 

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -14,6 +14,8 @@
 
 # define CHILD_PID		0
 # define PROMPT_NAME    "minishell "
+# define READ			0
+# define WRITE			1
 
 # define EXIT_CODE_NO_SUCH_FILE	127
 
@@ -31,6 +33,8 @@ void	debug_func(const char *func_name, const int line_num);
 void	debug_2d_array(char **array);
 
 /* exec */
+bool	is_first_command(int prev_fd);
+bool	is_last_command(char *next_cmd);
 void	child_process(t_command *cmd, int pipefd[2], int prev_fd, char **environ);
 int		execute_command(t_command *commands);
 int		parent_process(t_command *cmd, int pipefd[2], int *prev_fd, pid_t pid, int *last_exit_status);

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -9,6 +9,7 @@
 # define EXECVE_ERROR	(-1)
 # define FORK_ERROR		(-1)
 # define WAIT_ERROR		(-1)
+# define PIPE_ERROR		(-1)
 # define PROCESS_ERROR	(-1)
 
 # define CHILD_PID		0
@@ -30,9 +31,9 @@ void	debug_func(const char *func_name, const int line_num);
 void	debug_2d_array(char **array);
 
 /* exec */
-void	child_process(t_command *commands, char **environ);
+void	child_process(t_command *cmd, int pipefd[2], int prev_fd, char **environ);
 int		execute_command(t_command *commands);
-int		parent_process(int *last_exit_status);
+int		parent_process(t_command *cmd, int pipefd[2], int *prev_fd, pid_t pid, int *last_exit_status);
 
 /* input */
 char	*input_line(void);

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -40,6 +40,7 @@ void	debug_2d_array(char **array);
 /* exec */
 bool	is_first_command(int prev_fd);
 bool	is_last_command(char *next_cmd);
+int		handle_child_pipes(t_command *cmd, t_fd *fd);
 void	child_process(t_command *cmd, t_fd *fd, char **environ);
 int		execute_command(t_command *commands);
 int		handle_parent_pipes(t_command *cmd, t_fd *fd);

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -27,6 +27,11 @@ typedef struct s_command {
 	char	**next_command;
 }	t_command;
 
+typedef struct s_fd {
+	int	pipefd[2];
+	int	prev_fd;
+}	t_fd;
+
 // temporarily here ...
 /* debug */
 void	debug_func(const char *func_name, const int line_num);
@@ -35,9 +40,9 @@ void	debug_2d_array(char **array);
 /* exec */
 bool	is_first_command(int prev_fd);
 bool	is_last_command(char *next_cmd);
-void	child_process(t_command *cmd, int pipefd[2], int prev_fd, char **environ);
+void	child_process(t_command *cmd, t_fd *fd, char **environ);
 int		execute_command(t_command *commands);
-int		parent_process(t_command *cmd, int pipefd[2], int *prev_fd, pid_t pid, int *last_exit_status);
+int		parent_process(t_command *cmd, t_fd *fd, pid_t pid, int *last_exit_status);
 
 /* input */
 char	*input_line(void);

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -42,7 +42,9 @@ bool	is_first_command(int prev_fd);
 bool	is_last_command(char *next_cmd);
 void	child_process(t_command *cmd, t_fd *fd, char **environ);
 int		execute_command(t_command *commands);
-int		parent_process(t_command *cmd, t_fd *fd, pid_t pid, int *last_exit_status);
+int		handle_parent_pipes(t_command *cmd, t_fd *fd);
+int		parent_process(\
+					t_command *cmd, t_fd *fd, pid_t pid, int *last_exit_status);
 
 /* input */
 char	*input_line(void);

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -24,7 +24,7 @@ void	debug_func(const char *func_name, const int line_num);
 void	debug_2d_array(char **array);
 
 /* exec */
-int		exec(char **commands);
+int		execute_command(char **exec_command);
 
 /* input */
 char	*input_line(void);

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -18,10 +18,10 @@
 
 # define EXIT_MSG_NO_SUCH_FILE  "No such file or directory"
 
-// exec
+/* exec */
 int		exec(char **commands);
 
-// input
+/* input */
 char	*input_line(void);
 
 #endif

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -21,6 +21,7 @@
 typedef struct s_command {
 	char	**head;
 	char	**exec_command;
+	char	**next_command;
 }	t_command;
 
 // temporarily here ...

--- a/srcs/debug/put.c
+++ b/srcs/debug/put.c
@@ -1,0 +1,20 @@
+#include "ft_dprintf.h"
+
+// __func__, __LINE__
+void	debug_func(const char *func_name, const int line_num)
+{
+	ft_dprintf(STDERR_FILENO, "(%s: line %d)\n", func_name, line_num);
+}
+
+void	debug_2d_array(char **array)
+{
+	size_t	i;
+
+	i = 0;
+	while (array[i])
+	{
+		ft_dprintf(STDERR_FILENO, "%s ", array[i]);
+		i++;
+	}
+	ft_dprintf(STDERR_FILENO, "\n");
+}

--- a/srcs/exec/check_command.c
+++ b/srcs/exec/check_command.c
@@ -1,0 +1,11 @@
+#include "minishell.h"
+
+bool	is_first_command(int prev_fd)
+{
+	return (prev_fd == STDIN_FILENO);
+}
+
+bool	is_last_command(char *next_cmd)
+{
+	return (!next_cmd);
+}

--- a/srcs/exec/child_pipes.c
+++ b/srcs/exec/child_pipes.c
@@ -1,0 +1,41 @@
+#include "minishell.h"
+#include "libft.h"
+
+static int	handle_child_pipes_except_first(t_fd *fd)
+{
+	if (x_close(STDIN_FILENO) == PROCESS_ERROR)
+		return (PROCESS_ERROR);
+	if (x_dup2(fd->prev_fd, STDIN_FILENO) == PROCESS_ERROR)
+		return (PROCESS_ERROR);
+	if (x_close(fd->prev_fd) == PROCESS_ERROR)
+		return (PROCESS_ERROR);
+	return (EXIT_SUCCESS);
+}
+
+static int	handle_child_pipes_except_last(t_fd *fd)
+{
+	if (x_close(fd->pipefd[READ]) == PROCESS_ERROR)
+		return (PROCESS_ERROR);
+	if (x_close(STDOUT_FILENO) == PROCESS_ERROR)
+		return (PROCESS_ERROR);
+	if (x_dup2(fd->pipefd[WRITE], STDOUT_FILENO) == PROCESS_ERROR)
+		return (PROCESS_ERROR);
+	if (x_close(fd->pipefd[WRITE]) == PROCESS_ERROR)
+		return (PROCESS_ERROR);
+	return (EXIT_SUCCESS);
+}
+
+int	handle_child_pipes(t_command *cmd, t_fd *fd)
+{
+	if (!is_first_command(fd->prev_fd))
+	{
+		if (handle_child_pipes_except_first(fd) == PROCESS_ERROR)
+			return (PROCESS_ERROR);
+	}
+	if (!is_last_command(*cmd->next_command))
+	{
+		if (handle_child_pipes_except_last(fd) == PROCESS_ERROR)
+			return (PROCESS_ERROR);
+	}
+	return (EXIT_SUCCESS);
+}

--- a/srcs/exec/child_process.c
+++ b/srcs/exec/child_process.c
@@ -1,0 +1,20 @@
+#include "minishell.h"
+#include "ft_dprintf.h"
+#include "libft.h"
+
+// use PROMPT_NAME
+void	child_process(char **commands, char **environ)
+{
+	debug_func(__func__, __LINE__);
+	debug_2d_array(commands);
+	// if (!commands[0])
+	// 	exit(EXIT_SUCCESS);
+	if (execve(commands[0], commands, environ) == EXECVE_ERROR)
+	{
+		// write or malloc error
+		ft_dprintf(STDERR_FILENO, "minishell: %s: %s\n", \
+											commands[0], EXIT_MSG_NO_SUCH_FILE);
+		free_2d_array(&commands);
+		exit(EXIT_CODE_NO_SUCH_FILE);
+	}
+}

--- a/srcs/exec/child_process.c
+++ b/srcs/exec/child_process.c
@@ -2,45 +2,6 @@
 #include "ft_dprintf.h"
 #include "libft.h"
 
-static int	handle_child_pipes_except_first(t_fd *fd)
-{
-	if (x_close(STDIN_FILENO) == PROCESS_ERROR)
-		return (PROCESS_ERROR);
-	if (x_dup2(fd->prev_fd, STDIN_FILENO) == PROCESS_ERROR)
-		return (PROCESS_ERROR);
-	if (x_close(fd->prev_fd) == PROCESS_ERROR)
-		return (PROCESS_ERROR);
-	return (EXIT_SUCCESS);
-}
-
-static int	handle_child_pipes_except_last(t_fd *fd)
-{
-	if (x_close(fd->pipefd[READ]) == PROCESS_ERROR)
-		return (PROCESS_ERROR);
-	if (x_close(STDOUT_FILENO) == PROCESS_ERROR)
-		return (PROCESS_ERROR);
-	if (x_dup2(fd->pipefd[WRITE], STDOUT_FILENO) == PROCESS_ERROR)
-		return (PROCESS_ERROR);
-	if (x_close(fd->pipefd[WRITE]) == PROCESS_ERROR)
-		return (PROCESS_ERROR);
-	return (EXIT_SUCCESS);
-}
-
-static int	handle_child_pipes(t_command *cmd, t_fd *fd)
-{
-	if (!is_first_command(fd->prev_fd))
-	{
-		if (handle_child_pipes_except_first(fd) == PROCESS_ERROR)
-			return (PROCESS_ERROR);
-	}
-	if (!is_last_command(*cmd->next_command))
-	{
-		if (handle_child_pipes_except_last(fd) == PROCESS_ERROR)
-			return (PROCESS_ERROR);
-	}
-	return (EXIT_SUCCESS);
-}
-
 // use PROMPT_NAME
 void	child_process(t_command *cmd, t_fd *fd, char **environ)
 {

--- a/srcs/exec/child_process.c
+++ b/srcs/exec/child_process.c
@@ -3,6 +3,7 @@
 #include "libft.h"
 
 // use PROMPT_NAME
+// if execve erorr, no need for auto perror.
 void	child_process(t_command *cmd, t_fd *fd, char **environ)
 {
 	char	**command;
@@ -14,7 +15,7 @@ void	child_process(t_command *cmd, t_fd *fd, char **environ)
 	// 	exit(EXIT_SUCCESS);
 	if (handle_child_pipes(cmd, fd) == PROCESS_ERROR)
 		exit(EXIT_FAILURE);
-	if (x_execve(command[0], command, environ) == EXECVE_ERROR)
+	if (execve(command[0], command, environ) == EXECVE_ERROR)
 	{
 		// write or malloc error..?
 		ft_dprintf(STDERR_FILENO, "minishell: %s: %s\n", \

--- a/srcs/exec/child_process.c
+++ b/srcs/exec/child_process.c
@@ -3,10 +3,12 @@
 #include "libft.h"
 
 // use PROMPT_NAME
-void	child_process(t_command *cmd, char **environ)
+void	child_process(t_command *cmd, int pipefd[2], int prev_fd, char **environ)
 {
 	char	**command;
 
+	(void)pipefd;
+	(void)prev_fd;
 	command = cmd->exec_command;
 	debug_func(__func__, __LINE__);
 	debug_2d_array(command);

--- a/srcs/exec/child_process.c
+++ b/srcs/exec/child_process.c
@@ -3,7 +3,7 @@
 #include "libft.h"
 
 // use PROMPT_NAME
-void	child_process(t_command *cmd, int pipefd[2], int prev_fd, char **environ)
+void	child_process(t_command *cmd, t_fd *fd, char **environ)
 {
 	char	**command;
 
@@ -12,20 +12,20 @@ void	child_process(t_command *cmd, int pipefd[2], int prev_fd, char **environ)
 	debug_2d_array(command);
 	// if (!command[0])
 	// 	exit(EXIT_SUCCESS);
-	if (!is_first_command(prev_fd))
+	if (!is_first_command(fd->prev_fd))
  	{
 		// SYS_ERROR
 		close(STDIN_FILENO);
-		dup2(prev_fd, STDIN_FILENO);
-		close(prev_fd);
+		dup2(fd->prev_fd, STDIN_FILENO);
+		close(fd->prev_fd);
 	}
 	if (!is_last_command(*cmd->next_command))
 	{
 		// SYS_ERROR
-		close(pipefd[READ]);
+		close(fd->pipefd[READ]);
 		close(STDOUT_FILENO);
-		dup2(pipefd[WRITE], STDOUT_FILENO);
-		close(pipefd[WRITE]);
+		dup2(fd->pipefd[WRITE], STDOUT_FILENO);
+		close(fd->pipefd[WRITE]);
 	}
 	if (execve(command[0], command, environ) == EXECVE_ERROR)
 	{

--- a/srcs/exec/child_process.c
+++ b/srcs/exec/child_process.c
@@ -26,26 +26,33 @@ static int	handle_child_pipes_except_last(t_fd *fd)
 	return (EXIT_SUCCESS);
 }
 
+static int	handle_child_pipes(t_command *cmd, t_fd *fd)
+{
+	if (!is_first_command(fd->prev_fd))
+	{
+		if (handle_child_pipes_except_first(fd) == PROCESS_ERROR)
+			return (PROCESS_ERROR);
+	}
+	if (!is_last_command(*cmd->next_command))
+	{
+		if (handle_child_pipes_except_last(fd) == PROCESS_ERROR)
+			return (PROCESS_ERROR);
+	}
+	return (EXIT_SUCCESS);
+}
+
 // use PROMPT_NAME
 void	child_process(t_command *cmd, t_fd *fd, char **environ)
 {
 	char	**command;
 
 	command = cmd->exec_command;
-	debug_func(__func__, __LINE__);
-	debug_2d_array(command);
+	// debug_func(__func__, __LINE__);
+	// debug_2d_array(command);
 	// if (!command[0])
 	// 	exit(EXIT_SUCCESS);
-	if (!is_first_command(fd->prev_fd))
- 	{
-		if (handle_child_pipes_except_first(fd) == PROCESS_ERROR)
-			exit(EXIT_FAILURE);
-	}
-	if (!is_last_command(*cmd->next_command))
-	{
-		if (handle_child_pipes_except_last(fd) == PROCESS_ERROR)
-			exit(EXIT_FAILURE);
-	}
+	if (handle_child_pipes(cmd, fd) == PROCESS_ERROR)
+		exit(EXIT_FAILURE);
 	if (execve(command[0], command, environ) == EXECVE_ERROR)
 	{
 		// write or malloc error..?

--- a/srcs/exec/child_process.c
+++ b/srcs/exec/child_process.c
@@ -3,18 +3,21 @@
 #include "libft.h"
 
 // use PROMPT_NAME
-void	child_process(char **commands, char **environ)
+void	child_process(t_command *cmd, char **environ)
 {
+	char	**command;
+
+	command = cmd->exec_command;
 	debug_func(__func__, __LINE__);
-	debug_2d_array(commands);
-	// if (!commands[0])
+	debug_2d_array(command);
+	// if (!command[0])
 	// 	exit(EXIT_SUCCESS);
-	if (execve(commands[0], commands, environ) == EXECVE_ERROR)
+	if (execve(command[0], command, environ) == EXECVE_ERROR)
 	{
 		// write or malloc error
 		ft_dprintf(STDERR_FILENO, "minishell: %s: %s\n", \
-											commands[0], EXIT_MSG_NO_SUCH_FILE);
-		free_2d_array(&commands);
+											command[0], EXIT_MSG_NO_SUCH_FILE);
+		free_2d_array(&cmd->head);
 		exit(EXIT_CODE_NO_SUCH_FILE);
 	}
 }

--- a/srcs/exec/child_process.c
+++ b/srcs/exec/child_process.c
@@ -7,18 +7,33 @@ void	child_process(t_command *cmd, int pipefd[2], int prev_fd, char **environ)
 {
 	char	**command;
 
-	(void)pipefd;
-	(void)prev_fd;
 	command = cmd->exec_command;
 	debug_func(__func__, __LINE__);
 	debug_2d_array(command);
 	// if (!command[0])
 	// 	exit(EXIT_SUCCESS);
+	if (!is_first_command(prev_fd))
+ 	{
+		// SYS_ERROR
+		close(STDIN_FILENO);
+		dup2(prev_fd, STDIN_FILENO);
+		close(prev_fd);
+	}
+	if (!is_last_command(*cmd->next_command))
+	{
+		// SYS_ERROR
+		close(pipefd[READ]);
+		close(STDOUT_FILENO);
+		dup2(pipefd[WRITE], STDOUT_FILENO);
+		close(pipefd[WRITE]);
+	}
 	if (execve(command[0], command, environ) == EXECVE_ERROR)
 	{
-		// write or malloc error
+		// write or malloc error..?
 		ft_dprintf(STDERR_FILENO, "minishell: %s: %s\n", \
 											command[0], EXIT_MSG_NO_SUCH_FILE);
+		perror("execve");
+		// leaks
 		free_2d_array(&cmd->head);
 		exit(EXIT_CODE_NO_SUCH_FILE);
 	}

--- a/srcs/exec/child_process.c
+++ b/srcs/exec/child_process.c
@@ -14,12 +14,11 @@ void	child_process(t_command *cmd, t_fd *fd, char **environ)
 	// 	exit(EXIT_SUCCESS);
 	if (handle_child_pipes(cmd, fd) == PROCESS_ERROR)
 		exit(EXIT_FAILURE);
-	if (execve(command[0], command, environ) == EXECVE_ERROR)
+	if (x_execve(command[0], command, environ) == EXECVE_ERROR)
 	{
 		// write or malloc error..?
 		ft_dprintf(STDERR_FILENO, "minishell: %s: %s\n", \
 											command[0], EXIT_MSG_NO_SUCH_FILE);
-		perror("execve");
 		// leaks
 		free_2d_array(&cmd->head);
 		exit(EXIT_CODE_NO_SUCH_FILE);

--- a/srcs/exec/exec.c
+++ b/srcs/exec/exec.c
@@ -2,16 +2,6 @@
 #include "ft_dprintf.h"
 #include "libft.h"
 
-bool	is_first_command(int prev_fd)
-{
-	return (prev_fd == STDIN_FILENO);
-}
-
-bool	is_last_command(char *next_cmd)
-{
-	return (!next_cmd);
-}
-
 static bool	is_pipe(const char *str)
 {
 	if (ft_strnlen(str, 2) == 1 && *str == '|')

--- a/srcs/exec/exec.c
+++ b/srcs/exec/exec.c
@@ -17,7 +17,10 @@ static char	**get_next_command(char **command)
 	while (*command && !is_pipe(*command))
 		command++;
 	if (*command)
+	{
+		*command = NULL;
 		command++;
+	}
 	return (command);
 }
 

--- a/srcs/exec/exec.c
+++ b/srcs/exec/exec.c
@@ -35,7 +35,7 @@ static int	dup_process_and_run(t_command *cmd, t_fd *fd, int *last_exit_status)
 		if (x_pipe(fd->pipefd) == PIPE_ERROR)
 			return (PIPE_ERROR);
 	}
-	// ft_dprintf(STDERR_FILENO, "[pipe: %d, %d]\n", fd->pipefd[0], fd->pipefd[1]);
+// ft_dprintf(STDERR_FILENO, "[pipe: %d, %d]\n", fd->pipefd[0], fd->pipefd[1]);
 	pid = x_fork();
 	if (pid == FORK_ERROR)
 		return (FORK_ERROR);

--- a/srcs/exec/exec.c
+++ b/srcs/exec/exec.c
@@ -24,7 +24,7 @@ static char	**get_next_command(char **command)
 	return (command);
 }
 
-static int	dup_process_and_run(char **exec_command, int *last_exit_status)
+static int	dup_process_and_run(t_command *cmd, int *last_exit_status)
 {
 	extern char	**environ;
 	pid_t		pid;
@@ -33,7 +33,7 @@ static int	dup_process_and_run(char **exec_command, int *last_exit_status)
 	if (pid == FORK_ERROR)
 		return (FORK_ERROR);
 	if (pid == CHILD_PID)
-		child_process(exec_command, environ);
+		child_process(cmd, environ);
 	else
 	{
 		if (parent_process(last_exit_status) == PROCESS_ERROR)
@@ -42,19 +42,18 @@ static int	dup_process_and_run(char **exec_command, int *last_exit_status)
 	return (EXIT_SUCCESS);
 }
 
-int	execute_command(char **exec_command)
+int	execute_command(t_command *cmd)
 {
 	int		last_exit_status;
 	char	**next_command;
 
 	last_exit_status = EXIT_SUCCESS;
-	while (*exec_command)
+	while (*cmd->exec_command)
 	{
-		next_command = get_next_command(exec_command);
-		if (dup_process_and_run(exec_command, &last_exit_status) \
-															== PROCESS_ERROR)
+		next_command = get_next_command(cmd->exec_command);
+		if (dup_process_and_run(cmd, &last_exit_status) == PROCESS_ERROR)
 			return (PROCESS_ERROR);
-		exec_command = next_command;
+		cmd->exec_command = next_command;
 	}
 	return (last_exit_status);
 }

--- a/srcs/exec/exec.c
+++ b/srcs/exec/exec.c
@@ -66,12 +66,9 @@ int	exec(char **exec_command)
 	while (*exec_command)
 	{
 		next_command = get_next_command(exec_command);
-		pid = fork();
+		pid = x_fork();
 		if (pid == FORK_ERROR)
-		{
-			perror("fork");
 			return (FORK_ERROR);
-		}
 		if (pid == CHILD_PID)
 			child_process(exec_command, environ);
 		else

--- a/srcs/exec/exec.c
+++ b/srcs/exec/exec.c
@@ -1,7 +1,12 @@
 #include "minishell.h"
 #include "libft.h"
 
-static bool	is_last_command(char *next_cmd)
+bool	is_first_command(int prev_fd)
+{
+	return (prev_fd == STDIN_FILENO);
+}
+
+bool	is_last_command(char *next_cmd)
 {
 	return (!next_cmd);
 }

--- a/srcs/exec/exec.c
+++ b/srcs/exec/exec.c
@@ -35,7 +35,7 @@ static int	dup_process_and_run(t_command *cmd, t_fd *fd, int *last_exit_status)
 		if (x_pipe(fd->pipefd) == PIPE_ERROR)
 			return (PIPE_ERROR);
 	}
-	ft_dprintf(STDERR_FILENO, "[pipe: %d, %d]\n", fd->pipefd[0], fd->pipefd[1]);
+	// ft_dprintf(STDERR_FILENO, "[pipe: %d, %d]\n", fd->pipefd[0], fd->pipefd[1]);
 	pid = x_fork();
 	if (pid == FORK_ERROR)
 		return (FORK_ERROR);

--- a/srcs/exec/exec.c
+++ b/srcs/exec/exec.c
@@ -44,16 +44,15 @@ static int	dup_process_and_run(t_command *cmd, int *last_exit_status)
 
 int	execute_command(t_command *cmd)
 {
-	int		last_exit_status;
-	char	**next_command;
+	int	last_exit_status;
 
 	last_exit_status = EXIT_SUCCESS;
 	while (*cmd->exec_command)
 	{
-		next_command = get_next_command(cmd->exec_command);
+		cmd->next_command = get_next_command(cmd->exec_command);
 		if (dup_process_and_run(cmd, &last_exit_status) == PROCESS_ERROR)
 			return (PROCESS_ERROR);
-		cmd->exec_command = next_command;
+		cmd->exec_command = cmd->next_command;
 	}
 	return (last_exit_status);
 }

--- a/srcs/exec/exec.c
+++ b/srcs/exec/exec.c
@@ -6,7 +6,8 @@
 // use PROMPT_NAME
 void	child_process(char **commands, char **environ)
 {
-	printf("chi : %p\n", commands);
+	debug_func(__func__, __LINE__);
+	debug_2d_array(commands);
 	// if (!commands[0])
 	// 	exit(EXIT_SUCCESS);
 	if (execve(commands[0], commands, environ) == EXECVE_ERROR)

--- a/srcs/exec/exec.c
+++ b/srcs/exec/exec.c
@@ -1,39 +1,5 @@
-#include <sys/wait.h> // wait
 #include "minishell.h"
-#include "ft_dprintf.h"
 #include "libft.h"
-
-// use PROMPT_NAME
-void	child_process(char **commands, char **environ)
-{
-	debug_func(__func__, __LINE__);
-	debug_2d_array(commands);
-	// if (!commands[0])
-	// 	exit(EXIT_SUCCESS);
-	if (execve(commands[0], commands, environ) == EXECVE_ERROR)
-	{
-		// write or malloc error
-		ft_dprintf(STDERR_FILENO, "minishell: %s: %s\n", \
-											commands[0], EXIT_MSG_NO_SUCH_FILE);
-		free_2d_array(&commands);
-		exit(EXIT_CODE_NO_SUCH_FILE);
-	}
-}
-
-int	parent_process(void)
-{
-	int		status;
-	pid_t	wait_pid;
-
-	status = 0;
-	wait_pid = wait(&status);
-	if (wait_pid == WAIT_ERROR)
-	{
-		perror("wait");
-		return (WAIT_ERROR);
-	}
-	return (WEXITSTATUS(status));
-}
 
 static bool	is_pipe(const char *str)
 {

--- a/srcs/exec/parent_pipes.c
+++ b/srcs/exec/parent_pipes.c
@@ -1,0 +1,32 @@
+#include "minishell.h"
+#include "libft.h"
+
+static int	handle_parent_pipes_except_first(t_fd *fd)
+{
+	if (x_close(fd->prev_fd) == PROCESS_ERROR)
+		return (PROCESS_ERROR);
+	return (EXIT_SUCCESS);
+}
+
+static int	handle_parent_pipes_except_last(t_fd *fd)
+{
+	fd->prev_fd = fd->pipefd[READ];
+	if (x_close(fd->pipefd[WRITE]) == PROCESS_ERROR)
+		return (PROCESS_ERROR);
+	return (EXIT_SUCCESS);
+}
+
+int	handle_parent_pipes(t_command *cmd, t_fd *fd)
+{
+	if (!is_first_command(fd->prev_fd))
+	{
+		if (handle_parent_pipes_except_first(fd) == PROCESS_ERROR)
+			return (PROCESS_ERROR);
+	}
+	if (!is_last_command(*cmd->next_command))
+	{
+		if (handle_parent_pipes_except_last(fd) == PROCESS_ERROR)
+			return (PROCESS_ERROR);
+	}
+	return (EXIT_SUCCESS);
+}

--- a/srcs/exec/parent_process.c
+++ b/srcs/exec/parent_process.c
@@ -46,8 +46,8 @@ int	parent_process(t_command *cmd, t_fd *fd, pid_t pid, int *last_exit_status)
 		return (PROCESS_ERROR);
 	if (wait_all_child_process(status) == PROCESS_ERROR)
 		return (PROCESS_ERROR);
-	// ft_dprintf(STDERR_FILENO, "\nchild exit success!\n");
-	// ft_dprintf(STDERR_FILENO, "status: %d, exit status: %d\n", \
-	// 							WIFEXITED(status), last_exit_status);
+	// ft_dprintf(STDERR_FILENO, "\nchild exit success! ");
+	// ft_dprintf(STDERR_FILENO, "status: %d,", WIFEXITED(status));
+	// ft_dprintf(STDERR_FILENO, "exit status: %d\n", *last_exit_status);
 	return (EXIT_SUCCESS);
 }

--- a/srcs/exec/parent_process.c
+++ b/srcs/exec/parent_process.c
@@ -46,8 +46,8 @@ int	parent_process(t_command *cmd, t_fd *fd, pid_t pid, int *last_exit_status)
 		return (PROCESS_ERROR);
 	if (wait_all_child_process(status) == PROCESS_ERROR)
 		return (PROCESS_ERROR);
-	ft_dprintf(STDERR_FILENO, "\nchild exit success!\n");
-	ft_dprintf(STDERR_FILENO, "status: %d, exit status: %d\n", \
-								WIFEXITED(status), last_exit_status);
+	// ft_dprintf(STDERR_FILENO, "\nchild exit success!\n");
+	// ft_dprintf(STDERR_FILENO, "status: %d, exit status: %d\n", \
+	// 							WIFEXITED(status), last_exit_status);
 	return (EXIT_SUCCESS);
 }

--- a/srcs/exec/parent_process.c
+++ b/srcs/exec/parent_process.c
@@ -1,50 +1,80 @@
 #include <sys/wait.h> // wait
-#include <errno.h>
+#include <errno.h> // ECHILD
 #include "minishell.h"
 #include "ft_dprintf.h"
+#include "libft.h"
 
-int	parent_process(t_command *cmd, t_fd *fd, pid_t pid, int *last_exit_status)
+static int	handle_parent_pipes_except_first(t_fd *fd)
 {
-	int		status;
-	pid_t	wait_pid;
+	if (x_close(fd->prev_fd) == PROCESS_ERROR)
+		return (PROCESS_ERROR);
+	return (EXIT_SUCCESS);
+}
 
-	(void)cmd;
+static int	handle_parent_pipes_except_last(t_fd *fd)
+{
+	fd->prev_fd = fd->pipefd[READ];
+	if (x_close(fd->pipefd[WRITE]) == PROCESS_ERROR)
+		return (PROCESS_ERROR);
+	return (EXIT_SUCCESS);
+}
+
+static int	handle_parent_pipes(t_command *cmd, t_fd *fd)
+{
 	if (!is_first_command(fd->prev_fd))
 	{
-		// SYS_ERROR
-		close(fd->prev_fd);
+		if (handle_parent_pipes_except_first(fd) == PROCESS_ERROR)
+			return (PROCESS_ERROR);
 	}
 	if (!is_last_command(*cmd->next_command))
 	{
-		fd->prev_fd = fd->pipefd[READ];
-		// SYS_ERROR
-		close(fd->pipefd[WRITE]);
-		return (EXIT_SUCCESS);
+		if (handle_parent_pipes_except_last(fd) == PROCESS_ERROR)
+			return (PROCESS_ERROR);
 	}
-	wait_pid = waitpid(pid, &status, 0);
-	if (WIFEXITED(status))
-		*last_exit_status = WEXITSTATUS(status);
+	return (EXIT_SUCCESS);
+}
+
+static int	get_last_command_status(pid_t pid, int *status, int *last_exit_status)
+{
+	pid_t	wait_pid;
+
+	wait_pid = x_waitpid(pid, status, 0);
+	if (WIFEXITED(*status))
+		*last_exit_status = WEXITSTATUS(*status);
 	else
-	{
-		perror("waitpid");
-		return (PROCESS_ERROR);
-	}
+		return (WAIT_ERROR);
+	return (EXIT_SUCCESS);
+}
+
+static int	wait_all_child_process(int status)
+{
 	while (true)
 	{
-		wait_pid = wait(NULL);
-		if (wait_pid == WAIT_ERROR)
+		if (wait(NULL) != WAIT_ERROR)
+			continue ;
+		if (errno == ECHILD && WIFEXITED(status))
+			return (EXIT_SUCCESS);
+		else
 		{
-			if (errno == ECHILD && WIFEXITED(status))
-			{
-				ft_dprintf(STDERR_FILENO, "\nchild exit success! status: %d, last cmd exit status: %d\n", WIFEXITED(status), *last_exit_status);
-				return (EXIT_SUCCESS);
-			}
-			else
-			{
-				perror("wait");
-				return (PROCESS_ERROR);
-			}
+			perror("wait");
+			return (PROCESS_ERROR);
 		}
 	}
+	return (EXIT_SUCCESS);
+}
+
+int	parent_process(t_command *cmd, t_fd *fd, pid_t pid, int *last_exit_status)
+{
+	int	status;
+
+	if (handle_parent_pipes(cmd, fd) == PROCESS_ERROR)
+		exit(EXIT_FAILURE);
+	if (get_last_command_status(pid, &status, last_exit_status) == PROCESS_ERROR)
+		return (PROCESS_ERROR);
+	if (wait_all_child_process(status) == PROCESS_ERROR)
+		return (PROCESS_ERROR);
+	ft_dprintf(STDERR_FILENO, "\nchild exit success!\n");
+	ft_dprintf(STDERR_FILENO, "status: %d, exit status: %d\n", \
+								WIFEXITED(status), last_exit_status);
 	return (EXIT_SUCCESS);
 }

--- a/srcs/exec/parent_process.c
+++ b/srcs/exec/parent_process.c
@@ -4,37 +4,8 @@
 #include "ft_dprintf.h"
 #include "libft.h"
 
-static int	handle_parent_pipes_except_first(t_fd *fd)
-{
-	if (x_close(fd->prev_fd) == PROCESS_ERROR)
-		return (PROCESS_ERROR);
-	return (EXIT_SUCCESS);
-}
-
-static int	handle_parent_pipes_except_last(t_fd *fd)
-{
-	fd->prev_fd = fd->pipefd[READ];
-	if (x_close(fd->pipefd[WRITE]) == PROCESS_ERROR)
-		return (PROCESS_ERROR);
-	return (EXIT_SUCCESS);
-}
-
-static int	handle_parent_pipes(t_command *cmd, t_fd *fd)
-{
-	if (!is_first_command(fd->prev_fd))
-	{
-		if (handle_parent_pipes_except_first(fd) == PROCESS_ERROR)
-			return (PROCESS_ERROR);
-	}
-	if (!is_last_command(*cmd->next_command))
-	{
-		if (handle_parent_pipes_except_last(fd) == PROCESS_ERROR)
-			return (PROCESS_ERROR);
-	}
-	return (EXIT_SUCCESS);
-}
-
-static int	get_last_command_status(pid_t pid, int *status, int *last_exit_status)
+static int	get_last_command_status(\
+								pid_t pid, int *status, int *last_exit_status)
 {
 	pid_t	wait_pid;
 
@@ -69,7 +40,8 @@ int	parent_process(t_command *cmd, t_fd *fd, pid_t pid, int *last_exit_status)
 
 	if (handle_parent_pipes(cmd, fd) == PROCESS_ERROR)
 		exit(EXIT_FAILURE);
-	if (get_last_command_status(pid, &status, last_exit_status) == PROCESS_ERROR)
+	if (get_last_command_status(pid, &status, last_exit_status) \
+															== PROCESS_ERROR)
 		return (PROCESS_ERROR);
 	if (wait_all_child_process(status) == PROCESS_ERROR)
 		return (PROCESS_ERROR);

--- a/srcs/exec/parent_process.c
+++ b/srcs/exec/parent_process.c
@@ -10,7 +10,7 @@ static int	get_last_command_status(\
 	pid_t	wait_pid;
 
 	wait_pid = x_waitpid(pid, status, 0);
-	if (WIFEXITED(*status))
+	if (wait_pid != PROCESS_ERROR && WIFEXITED(*status))
 		*last_exit_status = WEXITSTATUS(*status);
 	else
 		return (WAIT_ERROR);

--- a/srcs/exec/parent_process.c
+++ b/srcs/exec/parent_process.c
@@ -40,7 +40,7 @@ int	parent_process(t_command *cmd, t_fd *fd, pid_t pid, int *last_exit_status)
 	int	status;
 
 	if (handle_parent_pipes(cmd, fd) == PROCESS_ERROR)
-		exit(EXIT_FAILURE);
+		return (PROCESS_ERROR);
 	if (get_last_command_status(pid, &status, last_exit_status) \
 															== PROCESS_ERROR)
 		return (PROCESS_ERROR);

--- a/srcs/exec/parent_process.c
+++ b/srcs/exec/parent_process.c
@@ -17,6 +17,7 @@ static int	get_last_command_status(\
 	return (EXIT_SUCCESS);
 }
 
+// if wait error, no need for auto perror.
 static int	wait_all_child_process(int status)
 {
 	while (true)

--- a/srcs/exec/parent_process.c
+++ b/srcs/exec/parent_process.c
@@ -41,13 +41,16 @@ int	parent_process(t_command *cmd, t_fd *fd, pid_t pid, int *last_exit_status)
 
 	if (handle_parent_pipes(cmd, fd) == PROCESS_ERROR)
 		return (PROCESS_ERROR);
-	if (get_last_command_status(pid, &status, last_exit_status) \
-															== PROCESS_ERROR)
-		return (PROCESS_ERROR);
-	if (wait_all_child_process(status) == PROCESS_ERROR)
-		return (PROCESS_ERROR);
-	// ft_dprintf(STDERR_FILENO, "\nchild exit success! ");
-	// ft_dprintf(STDERR_FILENO, "status: %d,", WIFEXITED(status));
-	// ft_dprintf(STDERR_FILENO, "exit status: %d\n", *last_exit_status);
+	if (is_last_command(*cmd->next_command))
+	{
+		if (get_last_command_status(pid, &status, last_exit_status) \
+																== PROCESS_ERROR)
+			return (PROCESS_ERROR);
+		if (wait_all_child_process(status) == PROCESS_ERROR)
+			return (PROCESS_ERROR);
+		// ft_dprintf(STDERR_FILENO, "\nchild exit success! ");
+		// ft_dprintf(STDERR_FILENO, "status: %d,", WIFEXITED(status));
+		// ft_dprintf(STDERR_FILENO, "exit status: %d\n", *last_exit_status);
+	}
 	return (EXIT_SUCCESS);
 }

--- a/srcs/exec/parent_process.c
+++ b/srcs/exec/parent_process.c
@@ -3,22 +3,22 @@
 #include "minishell.h"
 #include "ft_dprintf.h"
 
-int	parent_process(t_command *cmd, int pipefd[2], int *prev_fd, pid_t pid, int *last_exit_status)
+int	parent_process(t_command *cmd, t_fd *fd, pid_t pid, int *last_exit_status)
 {
 	int		status;
 	pid_t	wait_pid;
 
 	(void)cmd;
-	if (!is_first_command(*prev_fd))
+	if (!is_first_command(fd->prev_fd))
 	{
 		// SYS_ERROR
-		close(*prev_fd);
+		close(fd->prev_fd);
 	}
 	if (!is_last_command(*cmd->next_command))
 	{
-		*prev_fd = pipefd[READ];
+		fd->prev_fd = fd->pipefd[READ];
 		// SYS_ERROR
-		close(pipefd[WRITE]);
+		close(fd->pipefd[WRITE]);
 		return (EXIT_SUCCESS);
 	}
 	wait_pid = waitpid(pid, &status, 0);

--- a/srcs/exec/parent_process.c
+++ b/srcs/exec/parent_process.c
@@ -44,13 +44,14 @@ int	parent_process(t_command *cmd, t_fd *fd, pid_t pid, int *last_exit_status)
 	if (is_last_command(*cmd->next_command))
 	{
 		if (get_last_command_status(pid, &status, last_exit_status) \
-																== PROCESS_ERROR)
+															== PROCESS_ERROR)
 			return (PROCESS_ERROR);
 		if (wait_all_child_process(status) == PROCESS_ERROR)
 			return (PROCESS_ERROR);
 		// ft_dprintf(STDERR_FILENO, "\nchild exit success! ");
 		// ft_dprintf(STDERR_FILENO, "status: %d,", WIFEXITED(status));
 		// ft_dprintf(STDERR_FILENO, "exit status: %d\n", *last_exit_status);
+
 	}
 	return (EXIT_SUCCESS);
 }

--- a/srcs/exec/parent_process.c
+++ b/srcs/exec/parent_process.c
@@ -1,0 +1,18 @@
+#include <sys/wait.h> // wait
+#include "minishell.h"
+
+int	parent_process(int *last_exit_status)
+{
+	int		status;
+	pid_t	wait_pid;
+
+	status = 0;
+	wait_pid = wait(&status);
+	if (wait_pid == WAIT_ERROR)
+	{
+		perror("wait");
+		return (WAIT_ERROR);
+	}
+	*last_exit_status = WEXITSTATUS(status);
+	return (EXIT_SUCCESS);
+}

--- a/srcs/exec/parent_process.c
+++ b/srcs/exec/parent_process.c
@@ -1,11 +1,15 @@
 #include <sys/wait.h> // wait
 #include "minishell.h"
 
-int	parent_process(int *last_exit_status)
+int	parent_process(t_command *cmd, int pipefd[2], int *prev_fd, pid_t pid, int *last_exit_status)
 {
 	int		status;
 	pid_t	wait_pid;
 
+	(void)cmd;
+	(void)pipefd;
+	(void)prev_fd;
+	(void)pid;
 	status = 0;
 	wait_pid = wait(&status);
 	if (wait_pid == WAIT_ERROR)

--- a/srcs/input/input.c
+++ b/srcs/input/input.c
@@ -7,6 +7,7 @@ char	*input_line(void)
 {
 	char	*line;
 
+	rl_outstream = stderr;
 	line = readline(PROMPT_NAME);
 	if (!line)
 		return (NULL);

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -19,7 +19,7 @@ static int	minishell(void)
 		if (!commands)
 			return (EXIT_FAILURE);
 		// parse
-		process_status = exec(commands);
+		process_status = execute_command(commands);
 		free_2d_array(&commands);
 		if (process_status == PROCESS_ERROR)
 			return (EXIT_FAILURE);

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -5,6 +5,7 @@ static void	init_commands(t_command *cmd)
 {
 	cmd->head = NULL;
 	cmd->exec_command = NULL;
+	cmd->next_command = NULL;
 }
 
 static int	minishell(void)

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -1,7 +1,7 @@
 #include "minishell.h"
 #include "libft.h"
 
-int	minishell(void)
+static int	minishell(void)
 {
 	char	*line;
 	char	**commands;

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -1,12 +1,19 @@
 #include "minishell.h"
 #include "libft.h"
 
+static void	init_commands(t_command *cmd)
+{
+	cmd->head = NULL;
+	cmd->exec_command = NULL;
+}
+
 static int	minishell(void)
 {
-	char	*line;
-	char	**commands;
-	int		process_status;
+	char		*line;
+	t_command	cmd;
+	int			process_status;
 
+	init_commands(&cmd);
 	process_status = EXIT_SUCCESS;
 	while (true)
 	{
@@ -14,13 +21,14 @@ static int	minishell(void)
 		if (!line)
 			break ;
 		// tokenize
-		commands = ft_split(line, ' ');
+		cmd.head = ft_split(line, ' ');
 		free(line);
-		if (!commands)
+		if (!cmd.head)
 			return (EXIT_FAILURE);
+		cmd.exec_command = cmd.head;
 		// parse
-		process_status = execute_command(commands);
-		free_2d_array(&commands);
+		process_status = execute_command(&cmd);
+		free_2d_array(&cmd.head);
 		if (process_status == PROCESS_ERROR)
 			return (EXIT_FAILURE);
 	}


### PR DESCRIPTION
multi pipes だけ対応の動く minishell にする
- [x] 複数コマンドを独立に実行
- [x] pipe で繋いで複数コマンドを実行
- [x] 正常なコマンドのテストだけ追加

先頭や末尾の `|` は一旦未対応

-- review--
- [x] last command が終わってから wait するのを忘れていたので修正