### PR TITLE
update(minishell_pipe.py): add leak test

### DIFF
--- a/.github/sh/minishell_pipe.py
+++ b/.github/sh/minishell_pipe.py
@@ -265,12 +265,12 @@ def main():
 
     stdin = "/bin/echo aaa | /bin/cat -e"
     m_res, b_res = run_both_with_valgrind(stdin)
-    print(f'm_res:{m_res}')
+    # print(f'm_res:{m_res}')
     put_leak_result(val_leak, m_res, b_res)
 
     stdin = "/bin/echo aaa | nothing"
     m_res, b_res = run_both_with_valgrind(stdin)
-    print(f'm_res:{m_res}')
+    # print(f'm_res:{m_res}')
     put_leak_result(val_leak, m_res, b_res)
 
     # add_val_to_leak(val, val_leak)

--- a/.github/sh/minishell_pipe.py
+++ b/.github/sh/minishell_pipe.py
@@ -181,7 +181,7 @@ def put_total_leak_result(val_leak):
     print(skip, end="")
     print(f' (test case: {test_num - 1})')
     print("#########################################")
-    if ok == test_num - 1:
+    if ko == 0:
         return 0
     else:
         return 1
@@ -267,10 +267,10 @@ def main():
     # add_val_to_leak(val, val_leak)
 
     test_res |= put_total_leak_result(val_leak)
-
+    # test_res = 0
     # ===============================
 
-    return test_res
+    exit(test_res)
 
 if __name__ == '__main__':
     main()

--- a/.github/sh/minishell_pipe.py
+++ b/.github/sh/minishell_pipe.py
@@ -256,6 +256,7 @@ def main():
 
     # ===============================
     # print("\n ----- leaks -----")
+    print("\n\n")
     leak_test_num = 1
     leak_ok = 0
     leak_ko = 0

--- a/.github/sh/minishell_pipe.py
+++ b/.github/sh/minishell_pipe.py
@@ -30,6 +30,7 @@ def print_color_str_no_lf(color=WHITE, text=""):
 def get_leak_res(stderr):
     is_leak_occurred = False
     sum_bytes = 0
+    last_summary = 0
     val_results = stderr.split()
     val_res_len = len(val_results)
 
@@ -66,7 +67,7 @@ def run_minishell_with_valgrind(stdin, cmd):
     print(f'cmd:{stdin}', end='\n')
     if res_minishell.stderr:
         is_leak, leak_bytes = get_leak_res(res_minishell.stderr)
-        print(f' minishell leaks : {leak_bytes} bytes, {is_leak}')
+        print(f' minishell leaks : {leak_bytes} bytes')
         return is_leak
     return None
 
@@ -254,7 +255,7 @@ def main():
     test_res |= put_total_result(val)
 
     # ===============================
-    print("\n ----- leaks -----")
+    # print("\n ----- leaks -----")
     leak_test_num = 1
     leak_ok = 0
     leak_ko = 0

--- a/.github/sh/minishell_pipe.py
+++ b/.github/sh/minishell_pipe.py
@@ -21,6 +21,69 @@ def print_color_str_no_lf(color=WHITE, text=""):
     print(COLOR_DICT[color] + text + COLOR_DICT["end"], end="")
 
 
+
+# ----------------------------------------------------------
+# res_valgrind
+
+def get_leak_res(stderr):
+    is_leak_occurred = False
+    sum_bytes = 0
+    summary_no = 0
+    last_summary = 0
+
+    # print(stderr)
+    results = stderr.split()
+    for i in range(len(results)):
+        if (results[i] == "LEAK" and results[i + 1] == "SUMMARY:"):
+            last_summary = sum_bytes
+            sum_bytes = 0
+            summary_no += 1
+        for lost in ["definitely", "indirectly", "possibly"]:
+            if (results[i] == lost and results[i + 2].isdigit()):
+                leak_bytes = int(results[i + 2])
+                # print lost bytes
+                # print(f'{lost}:{leak_bytes}')
+                is_leak_occurred = True
+                sum_bytes += leak_bytes
+
+    # print valgrind result
+    # print(f'\nvalgrind res:\n{stderr}')
+    last_summary = sum_bytes
+    return is_leak_occurred, last_summary
+
+def run_cmd_with_valgrind(stdin=None, cmd=None):
+    valgrind="valgrind "
+    try:
+        res = subprocess.run(valgrind + cmd, input=stdin, capture_output=True, text=True, shell=True, timeout=2)
+        return res
+    except subprocess.TimeoutExpired as e:
+        print(e.cmd)
+
+def run_minishell_with_valgrind(stdin, cmd):
+    res_minishell = run_cmd_with_valgrind(stdin, cmd)
+    print(f'cmd:{stdin}', end='\n')
+    if res_minishell.stderr:
+        print("=== minishell(leaks) ===")
+        is_leak, leak_bytes = get_leak_res(res_minishell.stderr)
+        print(f'lesk : {leak_bytes} bytes')
+        return is_leak
+    return None
+
+def run_bash_with_valgrind(stdin, cmd):
+    res_bash = run_cmd_with_valgrind(stdin, cmd)
+    if res_bash.stderr:
+        print("===== bash(leaks) =====")
+        is_leak, leak_bytes = get_leak_res(res_bash.stderr)
+        print(f'lesk : {leak_bytes} bytes')
+        return is_leak
+    return None
+
+def run_both_with_valgrind(stdin):
+    leak_res_minishell = run_minishell_with_valgrind(stdin, PATH)
+    leak_res_bash = run_bash_with_valgrind(None, stdin)
+    return leak_res_minishell, leak_res_bash
+
+
 # ----------------------------------------------------------
 # run
 def run_cmd(stdin=None, cmd=None):
@@ -79,6 +142,29 @@ def put_result(val, m_res, b_res):
     val[0] += 1
     print()
 
+
+def put_leak_result(val_leak, m_res, b_res):
+    test_num, _, _ = val_leak
+    if m_res is None or b_res is None:
+        print_color_str(RED, f'[{test_num}. timeout]')
+        # ko
+        val_leak[2] += 1
+    elif (m_res == False):
+        print_color_str(GREEN, f'[{test_num}. OK]')
+        # ok
+        val_leak[1] += 1
+    else:
+        print_color_str(RED, f'[{test_num}. KO]')
+        # ko
+        val_leak[2] += 1
+    # test_num
+    val_leak[0] += 1
+    print()
+
+def add_val_to_leak(val, val_leak):
+    for i in range(len(val)):
+        val[i] += val_leak[i]
+
 def put_total_result(val):
     test_num, ok, ko = val
     print()
@@ -98,6 +184,7 @@ def main():
     ok = 0
     ko = 0
     val = [test_num, ok, ko]
+    val_leak = [test_num, ok, ko]
 
     stdin = "/bin/ls -l"
     m_res, b_res = run_both(stdin)
@@ -119,6 +206,7 @@ def main():
     m_res, b_res = run_both(stdin)
     put_result(val, m_res, b_res)
 
+
     # stdin = "/bin/echo -e aaa\naacc\nbbb\nbbcc\nccc\naabb\nabc | /bin/grep a | /bin/grep c"
     # m_res, b_res = run_both(stdin)
     # put_result(val, m_res, b_res)
@@ -132,6 +220,19 @@ def main():
 
     # stdin = "aa\nbb\ncc\nbbaa\n"
     # "cat | cat | cat | grep b"
+
+
+    print("----- valgdind -----\n")
+
+    # why leak ??
+    stdin = "/bin/echo aaa | /bin/cat -e"
+    m_res, b_res = run_both_with_valgrind(stdin)
+    put_leak_result(val, m_res, b_res)
+
+    # leak
+    stdin = "/bin/echo aaa | nothing"
+    m_res, b_res = run_both_with_valgrind(stdin)
+    put_leak_result(val, m_res, b_res)
 
     put_total_result(val)
 


### PR DESCRIPTION
valgrindの結果(stderr)からleakの結果を受け取り評価するテストを追加
（definitely lost, indirectly lost, possibly lostから、leakの有無、leak bytesを評価）

~terminalでの実行結果と、pythonでの実行結果が異なり、整合性が怪しい...??~
minishell終了時のleaks report見てなかっただけでした😇
最後まで見るとleaks byteも一致していた...

 <br>

~* stdin = "/bin/echo aaa | /bin/cat -e"~
 ~- terminal で`vargrind ./minishell; /bin/echo aaa | /bin/cat -e` だとleakなし~
 ~- pyだとleakあり~
~* stdin = "/bin/echo aaa | nothing"~
 ~- terminal で`vargrind ./minishell; //bin/echo aaa | nothing` だとleakあり~
  ~- pyだとleakあり~
