### PR TITLE
51 tokenize

### DIFF
--- a/.github/workflows/minishell_pipe.yml
+++ b/.github/workflows/minishell_pipe.yml
@@ -16,7 +16,7 @@ jobs:
       - name: make
         run: make
 
-      - name: Install python3.
-        run: python3 -m pip install --upgrade pip setuptools
-      - name: Minishell multi pipe check.
-        run: python3 .github/sh/minishell_pipe.py
+      # - name: Install python3.
+      #   run: python3 -m pip install --upgrade pip setuptools
+      # - name: Minishell multi pipe check.
+      #   run: python3 .github/sh/minishell_pipe.py

--- a/.github/workflows/minishell_pipe.yml
+++ b/.github/workflows/minishell_pipe.yml
@@ -16,7 +16,7 @@ jobs:
       - name: make
         run: make
 
-      # - name: Install python3.
-      #   run: python3 -m pip install --upgrade pip setuptools
-      # - name: Minishell multi pipe check.
-      #   run: python3 .github/sh/minishell_pipe.py
+      - name: Install python3.
+        run: python3 -m pip install --upgrade pip setuptools
+      - name: Minishell multi pipe check.
+        run: python3 .github/sh/minishell_pipe.py

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,9 @@ SRCS		+=	$(EXEC_DIR)/check_command.c \
 				$(EXEC_DIR)/parent_pipes.c \
 				$(EXEC_DIR)/parent_process.c
 
+TOKEN_DIR	:=	tokenize
+SRCS		+=	$(TOKEN_DIR)/tokenize.c
+
 INPUT_DIR	:=	input
 SRCS		+=	$(INPUT_DIR)/input.c
 

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ SRCS		+=	$(EXEC_DIR)/check_command.c \
 				$(EXEC_DIR)/child_pipes.c \
 				$(EXEC_DIR)/child_process.c \
 				$(EXEC_DIR)/exec.c \
+				$(EXEC_DIR)/init.c \
 				$(EXEC_DIR)/parent_pipes.c \
 				$(EXEC_DIR)/parent_process.c
 

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -21,12 +21,19 @@
 
 # define EXIT_MSG_NO_SUCH_FILE  "No such file or directory"
 
-typedef struct s_deque	t_deque;
+typedef struct s_deque_node	t_deque_node;
+typedef struct s_deque		t_deque;
+
+// typedef struct s_command {
+// 	char	**head;
+// 	char	**exec_command;
+// 	char	**next_command;
+// }	t_command;
 
 typedef struct s_command {
-	char	**head;
-	char	**exec_command;
-	char	**next_command;
+	t_deque			*head_command;
+	char			**exec_command;
+	t_deque_node	*next_command;
 }	t_command;
 
 typedef struct s_fd {
@@ -41,7 +48,7 @@ void	debug_2d_array(char **array);
 
 /* exec */
 bool	is_first_command(int prev_fd);
-bool	is_last_command(char *next_cmd);
+bool	is_last_command(t_deque_node *next_cmd);
 int		handle_child_pipes(t_command *cmd, t_fd *fd);
 void	child_process(t_command *cmd, t_fd *fd, char **environ);
 int		execute_command(t_deque *command);

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -24,12 +24,6 @@
 typedef struct s_deque_node	t_deque_node;
 typedef struct s_deque		t_deque;
 
-// typedef struct s_command {
-// 	char	**head;
-// 	char	**exec_command;
-// 	char	**next_command;
-// }	t_command;
-
 typedef struct s_command {
 	t_deque			*head_command;
 	char			**exec_command;
@@ -43,20 +37,31 @@ typedef struct s_fd {
 
 // temporarily here ...
 /* debug */
+// put.c
 void	debug_func(const char *func_name, const int line_num);
 void	debug_2d_array(char **array);
 
 /* exec */
+// check_command.c
 bool	is_first_command(int prev_fd);
 bool	is_last_command(t_deque_node *next_cmd);
+// child_pipes.c
 int		handle_child_pipes(t_command *cmd, t_fd *fd);
+// child_proces.c
 void	child_process(t_command *cmd, t_fd *fd, char **environ);
+// exec.c
 int		execute_command(t_deque *command);
+// init.c
+void	init_cmd(t_command *cmd, t_deque *dq_cmd);
+void	init_fd(t_fd *fd);
+// parent_pipes.c
 int		handle_parent_pipes(t_command *cmd, t_fd *fd);
+// parent_process.c
 int		parent_process(\
 					t_command *cmd, t_fd *fd, pid_t pid, int *last_exit_status);
 
 /* input */
+// input.c
 char	*input_line(void);
 
 #endif

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -21,6 +21,8 @@
 
 # define EXIT_MSG_NO_SUCH_FILE  "No such file or directory"
 
+typedef struct s_deque	t_deque;
+
 typedef struct s_command {
 	char	**head;
 	char	**exec_command;
@@ -42,7 +44,7 @@ bool	is_first_command(int prev_fd);
 bool	is_last_command(char *next_cmd);
 int		handle_child_pipes(t_command *cmd, t_fd *fd);
 void	child_process(t_command *cmd, t_fd *fd, char **environ);
-int		execute_command(t_command *commands);
+int		execute_command(t_deque *command);
 int		handle_parent_pipes(t_command *cmd, t_fd *fd);
 int		parent_process(\
 					t_command *cmd, t_fd *fd, pid_t pid, int *last_exit_status);

--- a/includes/tokenize.h
+++ b/includes/tokenize.h
@@ -1,0 +1,28 @@
+#ifndef TOKENIZE_H
+# define TOKENIZE_H
+
+# include <stdio.h>
+# include <stdlib.h>
+# include <stdbool.h>
+# include <unistd.h>
+
+typedef enum e_quote {
+	QUOTE_NONE = 0,
+	QUOTE_SINGLE = 1,
+	QUOTE_DOUBLE = 2
+}	t_quote;
+
+typedef enum e_concat {
+	CONCAT_NONE = 0,
+	CONCAT_PREV = 1,
+	CONCAT_NEXT = 2,
+	CONCAT_BOTH = 3
+}	t_concat;
+
+typedef struct s_token {
+	char			*str;
+	enum e_quote	quote;
+	enum e_concat	concat;
+}	t_token;
+
+#endif

--- a/includes/tokenize.h
+++ b/includes/tokenize.h
@@ -6,6 +6,8 @@
 # include <stdbool.h>
 # include <unistd.h>
 
+typedef struct s_deque	t_deque;
+
 typedef enum e_quote {
 	QUOTE_NONE = 0,
 	QUOTE_SINGLE = 1,
@@ -24,5 +26,8 @@ typedef struct s_token {
 	enum e_quote	quote;
 	enum e_concat	concat;
 }	t_token;
+
+/* tokenize */
+t_deque	*tokenize(char *line);
 
 #endif

--- a/libft/src/deque/dq_print.c
+++ b/libft/src/deque/dq_print.c
@@ -15,7 +15,7 @@ void	deque_print(t_deque *deque)
 	node = deque->node;
 	while (node)
 	{
-		// printf("[%s]", node->content);
+		printf("[%s]", (char *)node->content);
 		node = node->next;
 	}
 	printf("\nsize  : %zu\n", deque->size);

--- a/libft/src/deque/dq_print.c
+++ b/libft/src/deque/dq_print.c
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include "deque.h"
+#include "ft_dprintf.h"
 
 void	deque_print(t_deque *deque)
 {
@@ -7,23 +8,23 @@ void	deque_print(t_deque *deque)
 
 	if (deque_is_empty(deque))
 	{
-		printf("deque is empty!\n");
-		printf("---------------------\n");
+		ft_dprintf(STDERR_FILENO, "deque is empty!\n");
+		ft_dprintf(STDERR_FILENO, "---------------------\n");
 		return ;
 	}
-	printf("cotent: ");
+	ft_dprintf(STDERR_FILENO, "cotent: ");
 	node = deque->node;
 	while (node)
 	{
-		printf("[%s]", (char *)node->content);
+		ft_dprintf(STDERR_FILENO, "[%s]", (char *)node->content);
 		node = node->next;
 	}
-	printf("\nsize  : %zu\n", deque->size);
-	printf("---------------------\n");
+	ft_dprintf(STDERR_FILENO, "\nsize  : %zu\n", deque->size);
+	ft_dprintf(STDERR_FILENO, "---------------------\n");
 }
 
 void	debug_deque_print(t_deque *deque, const char *func_name)
 {
-	printf(">>> %s\n", func_name);
+	ft_dprintf(STDERR_FILENO, ">>> %s\n", func_name);
 	deque_print(deque);
 }

--- a/srcs/exec/check_command.c
+++ b/srcs/exec/check_command.c
@@ -1,11 +1,12 @@
 #include "minishell.h"
+#include "deque.h"
 
 bool	is_first_command(int prev_fd)
 {
 	return (prev_fd == STDIN_FILENO);
 }
 
-bool	is_last_command(char *next_cmd)
+bool	is_last_command(t_deque_node *next_cmd)
 {
 	return (!next_cmd);
 }

--- a/srcs/exec/child_pipes.c
+++ b/srcs/exec/child_pipes.c
@@ -32,7 +32,7 @@ int	handle_child_pipes(t_command *cmd, t_fd *fd)
 		if (handle_child_pipes_except_first(fd) == PROCESS_ERROR)
 			return (PROCESS_ERROR);
 	}
-	if (!is_last_command(*cmd->next_command))
+	if (!is_last_command(cmd->next_command))
 	{
 		if (handle_child_pipes_except_last(fd) == PROCESS_ERROR)
 			return (PROCESS_ERROR);

--- a/srcs/exec/child_process.c
+++ b/srcs/exec/child_process.c
@@ -21,7 +21,7 @@ void	child_process(t_command *cmd, t_fd *fd, char **environ)
 		ft_dprintf(STDERR_FILENO, "minishell: %s: %s\n", \
 											command[0], EXIT_MSG_NO_SUCH_FILE);
 		// leaks
-		free_2d_array(&cmd->head);
+		// free_2d_array(&cmd->head);
 		exit(EXIT_CODE_NO_SUCH_FILE);
 	}
 }

--- a/srcs/exec/child_process.c
+++ b/srcs/exec/child_process.c
@@ -1,4 +1,5 @@
 #include "minishell.h"
+#include "deque.h"
 #include "ft_dprintf.h"
 #include "libft.h"
 
@@ -20,8 +21,7 @@ void	child_process(t_command *cmd, t_fd *fd, char **environ)
 		// write or malloc error..?
 		ft_dprintf(STDERR_FILENO, "minishell: %s: %s\n", \
 											command[0], EXIT_MSG_NO_SUCH_FILE);
-		// leaks
-		// free_2d_array(&cmd->head);
+		deque_clear_all(&cmd->head_command);
 		exit(EXIT_CODE_NO_SUCH_FILE);
 	}
 }

--- a/srcs/exec/exec.c
+++ b/srcs/exec/exec.c
@@ -58,13 +58,11 @@ static int	dup_process_and_run(t_command *cmd, t_fd *fd, int *last_exit_status)
 	extern char	**environ;
 	pid_t		pid;
 
-	if (!cmd)
-		return (0);
-	// if (!is_last_command(*cmd->next_command))
-	// {
-	// 	if (x_pipe(fd->pipefd) == PIPE_ERROR)
-	// 		return (PIPE_ERROR);
-	// }
+	if (!is_last_command(cmd->next_command))
+	{
+		if (x_pipe(fd->pipefd) == PIPE_ERROR)
+			return (PIPE_ERROR);
+	}
 	pid = x_fork();
 	if (pid == FORK_ERROR)
 		return (FORK_ERROR);
@@ -94,10 +92,9 @@ int	execute_command(t_deque *dq_cmd)
 	{
 		cmd.next_command = get_next_command(node, &cmd_size);
 		cmd.exec_command = convert_command_to_array(node, cmd_size);
-		debug_2d_array(cmd.exec_command);
+		if (dup_process_and_run(&cmd, &fd, &last_exit_status) == PROCESS_ERROR)
+			return (PROCESS_ERROR);
 		free_2d_array(&cmd.exec_command);
-		// if (dup_process_and_run(cmd, &fd, &last_exit_status) == PROCESS_ERROR)
-		// 	return (PROCESS_ERROR);
 		node = cmd.next_command;
 	}
 	return (last_exit_status);

--- a/srcs/exec/exec.c
+++ b/srcs/exec/exec.c
@@ -31,6 +31,28 @@ static t_deque_node	*get_next_command(t_deque_node *cmd, size_t *cmd_size)
 	return (cmd);
 }
 
+static char	**convert_command_to_array(t_deque_node *node, const size_t size)
+{
+	char	**command;
+	char	*tmp;
+	size_t	i;
+
+	command = (char **)x_malloc(sizeof(char *) * (size + 1));
+	if (!command)
+		exit(EXIT_FAILURE);
+	i = 0;
+	while (i < size)
+	{
+		tmp = node->content;
+		node->content = NULL;
+		command[i] = tmp;
+		node = node->next;
+		i++;
+	}
+	command[i] = NULL;
+	return (command);
+}
+
 static int	dup_process_and_run(t_command *cmd, t_fd *fd, int *last_exit_status)
 {
 	extern char	**environ;
@@ -71,10 +93,9 @@ int	execute_command(t_deque *dq_cmd)
 	while (node)
 	{
 		cmd.next_command = get_next_command(node, &cmd_size);
-		printf("[cmd_size: %zu]\n", cmd_size);
-		// cmd.exec_command = convert_command_to_array(node, cmd_size);
-		if (dup_process_and_run(NULL, NULL, &last_exit_status) == PROCESS_ERROR)
-			return (PROCESS_ERROR);
+		cmd.exec_command = convert_command_to_array(node, cmd_size);
+		debug_2d_array(cmd.exec_command);
+		free_2d_array(&cmd.exec_command);
 		// if (dup_process_and_run(cmd, &fd, &last_exit_status) == PROCESS_ERROR)
 		// 	return (PROCESS_ERROR);
 		node = cmd.next_command;

--- a/srcs/exec/exec.c
+++ b/srcs/exec/exec.c
@@ -78,15 +78,15 @@ static int	dup_process_and_run(t_command *cmd, t_fd *fd, int *last_exit_status)
 
 int	execute_command(t_deque *dq_cmd)
 {
+	t_command		cmd;
 	t_fd			fd;
 	int				last_exit_status;
-	t_command		cmd;
 	t_deque_node	*node;
 	size_t			cmd_size;
 
-	fd.prev_fd = STDIN_FILENO;
+	init_cmd(&cmd, dq_cmd);
+	init_fd(&fd);
 	last_exit_status = EXIT_SUCCESS;
-	cmd.head_command = dq_cmd;
 	node = dq_cmd->node;
 	while (node)
 	{

--- a/srcs/exec/exec.c
+++ b/srcs/exec/exec.c
@@ -55,7 +55,7 @@ int	execute_command(t_deque *cmd_head)
 	t_fd			fd;
 	int				last_exit_status;
 	t_deque_node	*cmd;
-	t_deque_node	*next_cmd;
+	t_deque_node	*cmd_next;
 	size_t			cmd_size;
 
 	fd.prev_fd = STDIN_FILENO;
@@ -63,11 +63,11 @@ int	execute_command(t_deque *cmd_head)
 	cmd = cmd_head->node;
 	while (cmd)
 	{
-		next_cmd = get_next_command(cmd, &cmd_size);
+		cmd_next = get_next_command(cmd, &cmd_size);
 		printf("[cmd_size: %zu]\n", cmd_size);
 		// if (dup_process_and_run(head, cmd, &fd, &last_exit_status) == PROCESS_ERROR)
 		// 	return (PROCESS_ERROR);
-		cmd = next_cmd;
+		cmd = cmd_next;
 	}
 	return (last_exit_status);
 }

--- a/srcs/exec/exec.c
+++ b/srcs/exec/exec.c
@@ -23,51 +23,61 @@ static t_deque_node	*get_next_command(t_deque_node *cmd, size_t *cmd_size)
 		(*cmd_size)++;
 	}
 	if (cmd)
+	{
+		free(cmd->content);
+		cmd->content = NULL;
 		cmd = cmd->next;
+	}
 	return (cmd);
 }
 
-// static int	dup_process_and_run(t_command *cmd, t_fd *fd, int *last_exit_status)
-// {
-// 	extern char	**environ;
-// 	pid_t		pid;
+static int	dup_process_and_run(t_command *cmd, t_fd *fd, int *last_exit_status)
+{
+	extern char	**environ;
+	pid_t		pid;
 
-// 	if (!is_last_command(*cmd->next_command))
-// 	{
-// 		if (x_pipe(fd->pipefd) == PIPE_ERROR)
-// 			return (PIPE_ERROR);
-// 	}
-// 	pid = x_fork();
-// 	if (pid == FORK_ERROR)
-// 		return (FORK_ERROR);
-// 	if (pid == CHILD_PID)
-// 		child_process(cmd, fd, environ);
-// 	else
-// 	{
-// 		if (parent_process(cmd, fd, pid, last_exit_status) == PROCESS_ERROR)
-// 			return (PROCESS_ERROR);
-// 	}
-// 	return (EXIT_SUCCESS);
-// }
+	if (!cmd)
+		return (0);
+	// if (!is_last_command(*cmd->next_command))
+	// {
+	// 	if (x_pipe(fd->pipefd) == PIPE_ERROR)
+	// 		return (PIPE_ERROR);
+	// }
+	pid = x_fork();
+	if (pid == FORK_ERROR)
+		return (FORK_ERROR);
+	if (pid == CHILD_PID)
+		child_process(cmd, fd, environ);
+	else
+	{
+		if (parent_process(cmd, fd, pid, last_exit_status) == PROCESS_ERROR)
+			return (PROCESS_ERROR);
+	}
+	return (EXIT_SUCCESS);
+}
 
-int	execute_command(t_deque *cmd_head)
+int	execute_command(t_deque *dq_cmd)
 {
 	t_fd			fd;
 	int				last_exit_status;
-	t_deque_node	*cmd;
-	t_deque_node	*cmd_next;
+	t_command		cmd;
+	t_deque_node	*node;
 	size_t			cmd_size;
 
 	fd.prev_fd = STDIN_FILENO;
 	last_exit_status = EXIT_SUCCESS;
-	cmd = cmd_head->node;
-	while (cmd)
+	cmd.head_command = dq_cmd;
+	node = dq_cmd->node;
+	while (node)
 	{
-		cmd_next = get_next_command(cmd, &cmd_size);
+		cmd.next_command = get_next_command(node, &cmd_size);
 		printf("[cmd_size: %zu]\n", cmd_size);
-		// if (dup_process_and_run(head, cmd, &fd, &last_exit_status) == PROCESS_ERROR)
+		// cmd.exec_command = convert_command_to_array(node, cmd_size);
+		if (dup_process_and_run(NULL, NULL, &last_exit_status) == PROCESS_ERROR)
+			return (PROCESS_ERROR);
+		// if (dup_process_and_run(cmd, &fd, &last_exit_status) == PROCESS_ERROR)
 		// 	return (PROCESS_ERROR);
-		cmd = cmd_next;
+		node = cmd.next_command;
 	}
 	return (last_exit_status);
 }

--- a/srcs/exec/exec.c
+++ b/srcs/exec/exec.c
@@ -52,8 +52,8 @@ static t_deque_node	*get_next_command(t_deque_node *cmd, size_t *cmd_size)
 
 int	execute_command(t_deque *cmd_head)
 {
-	t_fd	fd;
-	int		last_exit_status;
+	t_fd			fd;
+	int				last_exit_status;
 	t_deque_node	*cmd;
 	t_deque_node	*next_cmd;
 	size_t			cmd_size;

--- a/srcs/exec/init.c
+++ b/srcs/exec/init.c
@@ -1,0 +1,16 @@
+#include "minishell.h"
+
+void	init_cmd(t_command *cmd, t_deque *dq_cmd)
+{
+	cmd->head_command = dq_cmd;
+	cmd->exec_command = NULL;
+	cmd->next_command = NULL;
+}
+
+// need..?
+void	init_fd(t_fd *fd)
+{
+	fd->pipefd[0] = 0;
+	fd->pipefd[1] = 0;
+	fd->prev_fd = STDIN_FILENO;
+}

--- a/srcs/exec/parent_pipes.c
+++ b/srcs/exec/parent_pipes.c
@@ -23,7 +23,7 @@ int	handle_parent_pipes(t_command *cmd, t_fd *fd)
 		if (handle_parent_pipes_except_first(fd) == PROCESS_ERROR)
 			return (PROCESS_ERROR);
 	}
-	if (!is_last_command(*cmd->next_command))
+	if (!is_last_command(cmd->next_command))
 	{
 		if (handle_parent_pipes_except_last(fd) == PROCESS_ERROR)
 			return (PROCESS_ERROR);

--- a/srcs/exec/parent_process.c
+++ b/srcs/exec/parent_process.c
@@ -41,7 +41,7 @@ int	parent_process(t_command *cmd, t_fd *fd, pid_t pid, int *last_exit_status)
 
 	if (handle_parent_pipes(cmd, fd) == PROCESS_ERROR)
 		return (PROCESS_ERROR);
-	if (is_last_command(*cmd->next_command))
+	if (is_last_command(cmd->next_command))
 	{
 		if (get_last_command_status(pid, &status, last_exit_status) \
 															== PROCESS_ERROR)

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -18,16 +18,13 @@ static int	minishell(void)
 		command = tokenize(line);
 		free(line);
 		debug_deque_print(command, __func__);
+		if (!command)
+			return (EXIT_FAILURE);
+		// parse()
+		process_status = execute_command(command);
 		deque_clear_all(&command);
-		// ----------------------------------
-		// if (!cmd.head)
-		// 	return (EXIT_FAILURE);
-		// cmd.exec_command = cmd.head;
-		// // parse
-		// process_status = execute_command(&cmd);
-		// free_2d_array(&cmd.head);
-		// if (process_status == PROCESS_ERROR)
-		// 	return (EXIT_FAILURE);
+		if (process_status == PROCESS_ERROR)
+			return (EXIT_FAILURE);
 	}
 	return (process_status);
 }

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -17,7 +17,6 @@ static int	minishell(void)
 			break ;
 		command = tokenize(line);
 		free(line);
-		// debug_deque_print(command, __func__);
 		if (!command)
 			return (EXIT_FAILURE);
 		// parse()

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -1,37 +1,33 @@
 #include "minishell.h"
-#include "libft.h"
-
-static void	init_commands(t_command *cmd)
-{
-	cmd->head = NULL;
-	cmd->exec_command = NULL;
-	cmd->next_command = NULL;
-}
+#include "tokenize.h"
+#include "deque.h"
 
 static int	minishell(void)
 {
-	char		*line;
-	t_command	cmd;
-	int			process_status;
+	t_deque	*command;
+	char	*line;
+	int		process_status;
 
-	init_commands(&cmd);
+	command = NULL;
 	process_status = EXIT_SUCCESS;
 	while (true)
 	{
 		line = input_line();
 		if (!line)
 			break ;
-		// tokenize
-		cmd.head = ft_split(line, ' ');
+		command = tokenize(line);
 		free(line);
-		if (!cmd.head)
-			return (EXIT_FAILURE);
-		cmd.exec_command = cmd.head;
-		// parse
-		process_status = execute_command(&cmd);
-		free_2d_array(&cmd.head);
-		if (process_status == PROCESS_ERROR)
-			return (EXIT_FAILURE);
+		debug_deque_print(command, __func__);
+		deque_clear_all(&command);
+		// ----------------------------------
+		// if (!cmd.head)
+		// 	return (EXIT_FAILURE);
+		// cmd.exec_command = cmd.head;
+		// // parse
+		// process_status = execute_command(&cmd);
+		// free_2d_array(&cmd.head);
+		// if (process_status == PROCESS_ERROR)
+		// 	return (EXIT_FAILURE);
 	}
 	return (process_status);
 }

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -17,7 +17,7 @@ static int	minishell(void)
 			break ;
 		command = tokenize(line);
 		free(line);
-		debug_deque_print(command, __func__);
+		// debug_deque_print(command, __func__);
 		if (!command)
 			return (EXIT_FAILURE);
 		// parse()

--- a/srcs/tokenize/tokenize.c
+++ b/srcs/tokenize/tokenize.c
@@ -1,0 +1,41 @@
+#include "minishell.h"
+#include "deque.h"
+#include "libft.h"
+
+static void	add_split_str_to_command(t_deque *command, char *split_str)
+{
+	char			*str;
+	t_deque_node	*node;
+
+	// to do: ft_strndup -> ft_strdup
+	str = ft_strndup(split_str, 20);
+	if (!str)
+		exit(EXIT_FAILURE);
+	node = deque_node_new((void *)str);
+	if (!node)
+		exit(EXIT_FAILURE);
+	deque_add_back(command, node);
+}
+
+// line: not NULL
+t_deque	*tokenize(char *line)
+{
+	char	**split_str;
+	t_deque	*command;
+	size_t	i;
+
+	split_str = ft_split(line, ' ');
+	if (!split_str)
+		exit(EXIT_FAILURE);
+	command = deque_new();
+	if (!command)
+		exit(EXIT_FAILURE);
+	i = 0;
+	while (split_str[i])
+	{
+		add_split_str_to_command(command, split_str[i]);
+		i++;
+	}
+	free_2d_array(&split_str);
+	return (command);
+}


### PR DESCRIPTION
文字列を適切に分けて情報を持たせ node に保持して次に渡す
- [x] シンプルスペース区切りで node に分割して多段パイプ ./minishell 実行
- [ ] `" "`、 `' '`、前後との結合情報なども持たせる
