### PR TITLE
ft_echo

### DIFF
--- a/.github/sh/minishell_pipe.py
+++ b/.github/sh/minishell_pipe.py
@@ -4,6 +4,7 @@ import shutil
 # ----------------------------------------------------------
 # OUT_FILE = "pipe_test_out.txt"
 PATH = "./minishell"
+PATH_BASH = "bash"
 
 # ----------------------------------------------------------
 # color
@@ -86,7 +87,7 @@ def run_both_with_valgrind(stdin):
         return None, None
 
     leak_res_minishell = run_minishell_with_valgrind(stdin, PATH)
-    leak_res_bash = run_bash_with_valgrind(None, stdin)
+    leak_res_bash = run_bash_with_valgrind(stdin, PATH_BASH)
     return leak_res_minishell, leak_res_bash
 
 
@@ -125,7 +126,7 @@ def run_bash(stdin, cmd):
 
 def run_both(stdin):
     res_minishell = run_minishell(stdin, PATH)
-    res_bash = run_bash(None, stdin)
+    res_bash = run_bash(stdin, PATH_BASH)
     return res_minishell, res_bash
 
 # ----------------------------------------------------------
@@ -212,9 +213,7 @@ def put_total_result(val):
 
 def test(test_name, test_input_arr):
     test_res = 0
-    print(f' =============================================================== ')
     print(f' ========================= {test_name} ========================= ')
-    print(f' =============================================================== ')
 
     # output test
     test_num = 1
@@ -241,8 +240,6 @@ def test(test_name, test_input_arr):
         put_leak_result(val_leak, m_res, b_res)
 
     test_res |= put_total_leak_result(val_leak)
-    print(f' =============================================================== ')
-    print(f' =============================================================== ')
     print()
     return test_res
 
@@ -250,14 +247,15 @@ def test(test_name, test_input_arr):
 def main():
     test_res = 0
 
-    pipe_test = ("/bin/ls -l",
-             "/bin/echo abcde",
-             "/bin/echo aaa bbb\n/bin/ls",
-             "/bin/echo aa\n/bin/echo bb\n/bin/echo ccc",
-             "/bin/echo aaa | /bin/grep a",
-             "/bin/echo aaa | /bin/cat -e",
-             "/bin/echo aaa | nothing",
-             )
+    # pipe_test = ("/bin/ls -l",
+    #          "/bin/echo abcde",
+    #          "/bin/echo aaa bbb\n/bin/ls",
+    #          "/bin/echo aa\n/bin/echo bb\n/bin/echo ccc",
+    #          "/bin/echo aaa | /bin/grep a",
+    #          "/bin/echo aaa | /bin/cat -e",
+    #          "/bin/echo aaa | nothing",
+    #          )
+    # test_res |= test("multi_pipe", pipe_test)
 
 
     # exit_status ...??
@@ -268,9 +266,9 @@ def main():
                  "echo a echo b echo c",
                  "echo aaaaaaaaaaaaaaaa bbbbbbbb  ccccccc echo   aa",
                  "echo /bin/echo a b c   d   e",
-                 "echo a \"\" b",
-                 "echo a \"\" \"\" \"\" b",
-                 "echo \"\"",
+                 # "echo a \"\" b",
+                 # "echo a \"\" \"\" \"\" b",
+                 # "echo \"\"",
                  "echo -n hello",
                  "echo -n hello -n",
                  "echo -----n hello",
@@ -292,7 +290,6 @@ def main():
                  "echo nnnn- a b c",
                  )
 
-    test_res |= test("multi_pipe", pipe_test)
     test_res |= test("ft_echo", echo_test)
 
 

--- a/.github/sh/minishell_pipe.py
+++ b/.github/sh/minishell_pipe.py
@@ -211,7 +211,7 @@ def put_total_result(val):
 
 # ----------------------------------------------------------
 
-def test(test_name, test_input_arr):
+def test(test_name, test_input_list):
     test_res = 0
     print(f' ========================= {test_name} ========================= ')
 
@@ -221,7 +221,7 @@ def test(test_name, test_input_arr):
     ko = 0
     val = [test_num, ok, ko]
 
-    for stdin in test_input_arr:
+    for stdin in test_input_list:
         m_res, b_res = run_both(stdin)
         put_result(val, m_res, b_res)
 
@@ -234,7 +234,7 @@ def test(test_name, test_input_arr):
     leak_skip = 0
     val_leak = [leak_test_num, leak_ok, leak_ko, leak_skip]
 
-    for stdin in test_input_arr:
+    for stdin in test_input_list:
         m_res, b_res = run_both_with_valgrind(stdin)
         # print(f'm_res:{m_res}')
         put_leak_result(val_leak, m_res, b_res)
@@ -247,19 +247,19 @@ def test(test_name, test_input_arr):
 def main():
     test_res = 0
 
-    # pipe_test = ("/bin/ls -l",
-    #          "/bin/echo abcde",
-    #          "/bin/echo aaa bbb\n/bin/ls",
-    #          "/bin/echo aa\n/bin/echo bb\n/bin/echo ccc",
-    #          "/bin/echo aaa | /bin/grep a",
-    #          "/bin/echo aaa | /bin/cat -e",
-    #          "/bin/echo aaa | nothing",
-    #          )
-    # test_res |= test("multi_pipe", pipe_test)
+    pipe_test = ["/bin/ls -l",
+             "/bin/echo abcde",
+             "/bin/echo aaa bbb\n/bin/ls",
+             "/bin/echo aa\n/bin/echo bb\n/bin/echo ccc",
+             "/bin/echo aaa | /bin/grep a",
+             "/bin/echo aaa | /bin/cat -e",
+             "/bin/echo aaa | nothing",
+             ]
+    test_res |= test("multi_pipe", pipe_test)
 
 
     # exit_status ...??
-    echo_test = ("echo",
+    echo_test = ["echo",
                  "echo a",
                  "echo a b c",
                  "echo a        b        c",
@@ -288,7 +288,7 @@ def main():
                  "echo -n-n a b c",
                  "echo nnnnnnn  -n a b c",
                  "echo nnnn- a b c",
-                 )
+                 ]
 
     test_res |= test("ft_echo", echo_test)
 

--- a/.github/sh/minishell_pipe.py
+++ b/.github/sh/minishell_pipe.py
@@ -273,6 +273,8 @@ def main():
                  "echo \"\"",
                  "echo -n hello",
                  "echo -n hello -n",
+                 "echo -----n hello",
+                 "echo -n -----n hello",
                  "echo -n -n -n -n -n  a  b  c",
                  "echo -n -n -n -n -n  a  b  c -n -n -n -m  d e f",
                  "echo -n -m hoge",

--- a/.github/sh/norm.py
+++ b/.github/sh/norm.py
@@ -76,7 +76,7 @@ def norm_check_exclude_header():
             exit(1)
 
 def run_norm(check_path):
-    cmd = "norminette " + check_path +  " > " + OUT_FILE
+    cmd = "python3 -m norminette " + check_path +  " > " + OUT_FILE
     print(cmd)
     run_cmd(cmd)
 

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+
 NAME	:=	minishell
 
 CC			:=	clang
@@ -25,6 +26,9 @@ SRCS		+=	$(TOKEN_DIR)/tokenize.c
 
 INPUT_DIR	:=	input
 SRCS		+=	$(INPUT_DIR)/input.c
+
+BUILTIN_DIR	:=	builtin
+SRCS		+=	$(BUILTIN_DIR)/ft_echo.c
 
 OBJ_DIR	:=	obj
 OBJS	:=	$(SRCS:%.c=$(OBJ_DIR)/%.o)

--- a/includes/builtin.h
+++ b/includes/builtin.h
@@ -1,6 +1,0 @@
-#ifndef BUILTIN_H
-# define BUILTIN_H
-
-int	ft_echo(char **cmds);
-
-#endif //BUILTIN_H

--- a/includes/builtin.h
+++ b/includes/builtin.h
@@ -1,6 +1,6 @@
 #ifndef BUILTIN_H
-#define BUILTIN_H
+# define BUILTIN_H
 
-
+int	ft_echo(char **cmds);
 
 #endif //BUILTIN_H

--- a/includes/builtin.h
+++ b/includes/builtin.h
@@ -1,0 +1,6 @@
+#ifndef BUILTIN_H
+#define BUILTIN_H
+
+
+
+#endif //BUILTIN_H

--- a/includes/ft_builtin.h
+++ b/includes/ft_builtin.h
@@ -1,6 +1,6 @@
-#ifndef BUILTIN_H
-# define BUILTIN_H
+#ifndef FT_BUILTIN_H
+# define FT_BUILTIN_H
 
 int	ft_echo(char **cmds);
 
-#endif //BUILTIN_H
+#endif //FT_BUILTIN_H

--- a/includes/ft_builtin.h
+++ b/includes/ft_builtin.h
@@ -1,0 +1,6 @@
+#ifndef BUILTIN_H
+# define BUILTIN_H
+
+int	ft_echo(char **cmds);
+
+#endif //BUILTIN_H

--- a/srcs/builtin/ft_echo.c
+++ b/srcs/builtin/ft_echo.c
@@ -58,11 +58,10 @@ static void	put_strings(char **strs)
 // cmds[0] == "echo"
 int	ft_echo(char **cmds)
 {
-	int		status;
-	size_t	idx;
-	bool	is_n_op_validate;
+	const int	status = EXIT_SUCCESS;
+	size_t		idx;
+	bool		is_n_op_validate;
 
-	status = EXIT_SUCCESS;
 	idx = 1;
 	skip_option_part(cmds, &idx, &is_n_op_validate);
 	put_strings(&cmds[idx]);

--- a/srcs/builtin/ft_echo.c
+++ b/srcs/builtin/ft_echo.c
@@ -1,6 +1,6 @@
 #include <stdbool.h>
 #include <stdlib.h>
-#include "builtins.h"
+#include "ft_builtin.h"
 #include "ft_dprintf.h"
 
 // valid option
@@ -21,7 +21,7 @@ static bool	is_n_option(const char *str)
 	i = 0;
 	while (str[i] == '-')
 		i++;
-	if (i != 1)
+	if (i != 1 || str[i] != 'n')
 		return (false);
 	while (str[i] == 'n')
 		i++;
@@ -30,33 +30,33 @@ static bool	is_n_option(const char *str)
 	return (true);
 }
 
-static void	skip_option_part(const char **cmds, size_t *idx, bool *is_valid_op)
+static void	skip_option_part(char **cmds, size_t *idx, bool *is_valid_op)
 {
 	*is_valid_op = false;
 	if (!cmds)
 		return ;
-	while (cmds[*i] && is_n_option(cmds[*i]))
-		*i += 1;
-	*is_valid_op = *i > 1;
+	while (cmds[*idx] && is_n_option(cmds[*idx]))
+		*idx += 1;
+	*is_valid_op = *idx > 1;
 }
 
-static void	put_strings(const char **strs)
+static void	put_strings(char **strs)
 {
-	size_t	i;
+	size_t	idx;
 
-	i = 0;
-	while (strs && strs[i])
+	idx = 0;
+	while (strs && strs[idx])
 	{
-		ft_dprintf(STDIN_FILENO, "%s", strs[i]);
-		i++;
-		if (strs[i])
-			ft_dprintf(STDIN_FILENO, " ",);
+		ft_dprintf(STDOUT_FILENO, "%s", strs[idx]);
+		idx++;
+		if (strs[idx])
+			ft_dprintf(STDOUT_FILENO, " ");
 	}
 }
 
 // cmds != NULL
 // cmds[0] == "echo"
-int	ft_echo(const char **cmds)
+int	ft_echo(char **cmds)
 {
 	int		status;
 	size_t	idx;
@@ -64,9 +64,9 @@ int	ft_echo(const char **cmds)
 
 	status = EXIT_SUCCESS;
 	idx = 1;
-	skip_option_part(&cmds[1], &idx, &is_n_op_validate);
+	skip_option_part(cmds, &idx, &is_n_op_validate);
 	put_strings(&cmds[idx]);
 	if (!is_n_op_validate)
-		ft_dprintf(STDIN_FILENO, "\n");
+		ft_dprintf(STDOUT_FILENO, "\n");
 	return (status);
 }

--- a/srcs/builtin/ft_echo.c
+++ b/srcs/builtin/ft_echo.c
@@ -1,0 +1,72 @@
+#include <stdbool.h>
+#include <stdlib.h>
+#include "builtins.h"
+#include "ft_dprintf.h"
+
+// valid option
+//  {"echo", "-n", NULL}
+//  {"echo, "-nnnnnnnn", NULL}
+//  {"echo", "-n", "-n", "-nnnn", "-n", "-nnnn", NULL}
+
+// invalid
+//  {"echo", "-n" "-nnnnnnm", NULL}
+//                 ^^^^^^^^ NOT OPTION
+
+static bool	is_n_option(const char *str)
+{
+	size_t	i;
+
+	if (!str)
+		return (false);
+	i = 0;
+	while (str[i] == '-')
+		i++;
+	if (i != 1)
+		return (false);
+	while (str[i] == 'n')
+		i++;
+	if (str[i])
+		return (false);
+	return (true);
+}
+
+static void	skip_option_part(const char **cmds, size_t *idx, bool *is_valid_op)
+{
+	*is_valid_op = false;
+	if (!cmds)
+		return ;
+	while (cmds[*i] && is_n_option(cmds[*i]))
+		*i += 1;
+	*is_valid_op = *i > 1;
+}
+
+static void	put_strings(const char **strs)
+{
+	size_t	i;
+
+	i = 0;
+	while (strs && strs[i])
+	{
+		ft_dprintf(STDIN_FILENO, "%s", strs[i]);
+		i++;
+		if (strs[i])
+			ft_dprintf(STDIN_FILENO, " ",);
+	}
+}
+
+// cmds != NULL
+// cmds[0] == "echo"
+int	ft_echo(const char **cmds)
+{
+	int		status;
+	size_t	idx;
+	bool	is_n_op_validate;
+
+	status = EXIT_SUCCESS;
+	idx = 1;
+	skip_option_part(&cmds[1], &idx, &is_n_op_validate);
+	put_strings(&cmds[idx]);
+	if (!is_n_op_validate)
+		ft_dprintf(STDIN_FILENO, "\n");
+	return (status);
+}

--- a/srcs/exec/child_process.c
+++ b/srcs/exec/child_process.c
@@ -2,6 +2,8 @@
 #include "deque.h"
 #include "ft_dprintf.h"
 #include "libft.h"
+#include "ft_string.h"
+#include "ft_builtin.h"
 
 // use PROMPT_NAME
 // if execve erorr, no need for auto perror.
@@ -16,6 +18,13 @@ void	child_process(t_command *cmd, t_fd *fd, char **environ)
 	// 	exit(EXIT_SUCCESS);
 	if (handle_child_pipes(cmd, fd) == PROCESS_ERROR)
 		exit(EXIT_FAILURE);
+	if (command[0] && ft_strncmp(command[0], "echo", 5) == 0)
+	{
+//		dprintf(STDERR_FILENO, "exec ft_echo");
+		ft_echo(command);
+		deque_clear_all(&cmd->head_command);
+		exit(EXIT_SUCCESS);
+	}
 	if (execve(command[0], command, environ) == EXECVE_ERROR)
 	{
 		// write or malloc error..?

--- a/srcs/exec/child_process.c
+++ b/srcs/exec/child_process.c
@@ -14,8 +14,6 @@ void	child_process(t_command *cmd, t_fd *fd, char **environ)
 	command = cmd->exec_command;
 	// debug_func(__func__, __LINE__);
 	// debug_2d_array(command);
-	// if (!command[0])
-	// 	exit(EXIT_SUCCESS);
 	if (handle_child_pipes(cmd, fd) == PROCESS_ERROR)
 		exit(EXIT_FAILURE);
 	if (command[0] && ft_strncmp(command[0], "echo", 5) == 0)

--- a/srcs/tokenize/tokenize.c
+++ b/srcs/tokenize/tokenize.c
@@ -8,7 +8,7 @@ static void	add_split_str_to_command(t_deque *command, char *split_str)
 	t_deque_node	*node;
 
 	// to do: ft_strndup -> ft_strdup
-	str = ft_strndup(split_str);
+	str = ft_strdup(split_str);
 	if (!str)
 		exit(EXIT_FAILURE);
 	node = deque_node_new((void *)str);

--- a/srcs/tokenize/tokenize.c
+++ b/srcs/tokenize/tokenize.c
@@ -8,7 +8,7 @@ static void	add_split_str_to_command(t_deque *command, char *split_str)
 	t_deque_node	*node;
 
 	// to do: ft_strndup -> ft_strdup
-	str = ft_strndup(split_str, 20);
+	str = ft_strndup(split_str);
 	if (!str)
 		exit(EXIT_FAILURE);
 	node = deque_node_new((void *)str);


### PR DESCRIPTION
- [x] `echo` (with `-n` option)
- [x] test

# echo
* echo追加しましたー！仕様は以下の通りです。
  - format : `echo [option] [argv]`
  - argvを`space`区切りで順番にputしていき, 末尾に`\n`を出力する
  - option `-n` があれば、末尾の`\n`は出力しない
  - option`-n`は`^-n+`であればoptionと認識し、空白区切りで連続している限りoptionとみなされる
  - 一度option以外の文字が解釈されれば、以降は`^-n+`も文字列とみなされる
* tokenizeの`ft_strndup`で20文字制限がかかっていたので、`ft_strdup`に変更しました！

# test update
* echo 用のテストケースの追加 & テストケースの一覧性向上のためtestの関数分割を行いました！
* test caseの配列をtest()に渡し、内部で1行ずつrunに渡していく形にしてみました
https://github.com/habvi/42_minishell/blob/9d0ba764b572899d6b32312d3f9605eafca05cba/.github/sh/minishell_pipe.py#L262-L293

* leakのテストは遅いです...
* `make pipe`で動作します（pipeに纏めちゃいましたが、分けた方が良かったかも...??）
* quoteを含むテストはまだKOなのでコメントアウトしていますー！

