### PR TITLE
add lib func for exit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,13 +28,8 @@ INPUT_DIR	:=	input
 SRCS		+=	$(INPUT_DIR)/input.c
 
 BUILTIN_DIR	:=	builtin
-<<<<<<< HEAD
-SRCS		+=	$(BUILTIN_DIR)/ft_echo.c
-=======
 SRCS		+=	$(BUILTIN_DIR)/ft_echo.c \
-				$(BUILTIN_DIR)/ft_exit.c \
 				$(BUILTIN_DIR)/ft_legal_number.c
->>>>>>> 3f634aa (add(ft_legal_number):implement ft_legal_number and add simple test)
 
 OBJ_DIR	:=	obj
 OBJS	:=	$(SRCS:%.c=$(OBJ_DIR)/%.o)

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,13 @@ INPUT_DIR	:=	input
 SRCS		+=	$(INPUT_DIR)/input.c
 
 BUILTIN_DIR	:=	builtin
+<<<<<<< HEAD
 SRCS		+=	$(BUILTIN_DIR)/ft_echo.c
+=======
+SRCS		+=	$(BUILTIN_DIR)/ft_echo.c \
+				$(BUILTIN_DIR)/ft_exit.c \
+				$(BUILTIN_DIR)/ft_legal_number.c
+>>>>>>> 3f634aa (add(ft_legal_number):implement ft_legal_number and add simple test)
 
 OBJ_DIR	:=	obj
 OBJS	:=	$(SRCS:%.c=$(OBJ_DIR)/%.o)

--- a/includes/ft_builtin.h
+++ b/includes/ft_builtin.h
@@ -1,6 +1,8 @@
 #ifndef FT_BUILTIN_H
 # define FT_BUILTIN_H
 
+# include <stdbool.h>
+
 typedef enum e_exit_argument
 {
 	EXIT_VALID_ARG,
@@ -8,6 +10,12 @@ typedef enum e_exit_argument
 	NOT_EXIT_TOO_MANY_NUMERIC_ARG,
 }	t_exit_arg;
 
+<<<<<<< HEAD
 int	ft_echo(char **cmds);
+=======
+int		ft_echo(char **cmds);
+int		ft_exit(char **cmds);
+bool	ft_legal_number(const char *str, long *result);
+>>>>>>> 3f634aa (add(ft_legal_number):implement ft_legal_number and add simple test)
 
 #endif //FT_BUILTIN_H

--- a/includes/ft_builtin.h
+++ b/includes/ft_builtin.h
@@ -1,6 +1,13 @@
 #ifndef FT_BUILTIN_H
 # define FT_BUILTIN_H
 
+typedef enum e_exit_argument
+{
+	EXIT_VALID_ARG,
+	EXIT_NON_NUMERIC_ARG,
+	NOT_EXIT_TOO_MANY_NUMERIC_ARG,
+}	t_exit_arg;
+
 int	ft_echo(char **cmds);
 
 #endif //FT_BUILTIN_H

--- a/includes/ft_builtin.h
+++ b/includes/ft_builtin.h
@@ -10,12 +10,7 @@ typedef enum e_exit_argument
 	NOT_EXIT_TOO_MANY_NUMERIC_ARG,
 }	t_exit_arg;
 
-<<<<<<< HEAD
-int	ft_echo(char **cmds);
-=======
 int		ft_echo(char **cmds);
-int		ft_exit(char **cmds);
 bool	ft_legal_number(const char *str, long *result);
->>>>>>> 3f634aa (add(ft_legal_number):implement ft_legal_number and add simple test)
 
 #endif //FT_BUILTIN_H

--- a/libft/Makefile
+++ b/libft/Makefile
@@ -34,7 +34,8 @@ LIB_SRC		:=	$(LIB_DIR)/ft_atoi_old.c \
 				$(LIB_DIR)/ft_atoi_strictly.c \
 				$(LIB_DIR)/ft_atoi.c \
 				$(LIB_DIR)/ft_itoa_int.c \
-				$(LIB_DIR)/ft_itoa.c
+				$(LIB_DIR)/ft_itoa.c \
+				$(LIB_DIR)/ft_strtol.c
 
 #--------------------------------------------
 # ft_list

--- a/libft/includes/ft_lib.h
+++ b/libft/includes/ft_lib.h
@@ -9,5 +9,6 @@ bool	ft_atoi_strictly(const char *str, int *num);
 bool	ft_atoi(const char *str, int *num);
 char	*ft_itoa_int(int n);
 char	*ft_itoa(int n);
+bool	ft_strtol(const char *str, long *ret_num, char **endptr);
 
 #endif

--- a/libft/src/ft_lib/ft_strtol.c
+++ b/libft/src/ft_lib/ft_strtol.c
@@ -1,0 +1,98 @@
+#include <limits.h>
+#include "ft_lib.h"
+#include "ft_ascii.h"
+#include <sys/errno.h>
+
+static bool	is_space(int c)
+{
+	return (c == '\t' || c == '\n' || c == '\v' || \
+			c == '\f' || c == '\r' || c == ' ');
+}
+
+static void	get_sign(const char *str, size_t *idx, int *sign)
+{
+	*sign = 1;
+	if (str[*idx] != '+' && str[*idx] != '-')
+		return ;
+	if (str[*idx] == '+')
+	{
+		*idx += 1;
+		return ;
+	}
+	if (str[*idx] == '-')
+	{
+		*idx += 1;
+		*sign = -1;
+	}
+}
+
+static bool	is_overflow(long before_x10_val, int add_val, int sign)
+{
+	long	ov_div;
+	long	ov_mod;
+
+	if (sign == 1)
+	{
+		ov_div = LONG_MAX / 10;
+		ov_mod = LONG_MAX % 10;
+	}
+	else
+	{
+		ov_div = -(LONG_MIN / 10);
+		ov_mod = -(LONG_MIN % 10);
+	}
+	if (before_x10_val > ov_div)
+		return (true);
+	if (before_x10_val == ov_div && add_val > ov_mod)
+		return (true);
+	return (false);
+}
+
+static long	get_long_num(const char *str, size_t *idx, int sign, bool *is_of)
+{
+	long	ret_num;
+	int		digit;
+
+	ret_num = 0;
+	*is_of = false;
+	while (ft_isdigit(str[*idx]))
+	{
+		digit = str[*idx] - '0';
+		if (is_overflow(ret_num, digit, sign))
+		{
+			*is_of = true;
+			while (ft_isdigit(str[*idx]))
+				*idx += 1;
+			if (sign == 1)
+				return (LONG_MAX);
+			return (LONG_MIN);
+		}
+		ret_num = ret_num * 10 + digit;
+		*idx += 1;
+	}
+	ret_num *= sign;
+	return (ret_num);
+}
+
+bool	ft_strtol(const char *str, long *ret_num, char **endptr)
+{
+	int		sign;
+	size_t	idx;
+	bool	is_overflow_occurred;
+
+	*ret_num = 0;
+	idx = 0;
+	if (endptr)
+		*endptr = (char *)&str[idx];
+	while (is_space(str[idx]))
+		idx++;
+	get_sign(str, &idx, &sign);
+	if (!ft_isdigit(str[idx]))
+		return (false);
+	*ret_num = get_long_num(str, &idx, sign, &is_overflow_occurred);
+	if (endptr)
+		*endptr = (char *)&str[idx];
+	if (is_overflow_occurred)
+		return (false);
+	return (true);
+}

--- a/srcs/builtin/ft_legal_number.c
+++ b/srcs/builtin/ft_legal_number.c
@@ -1,0 +1,28 @@
+#include <stdbool.h>
+#include "ft_builtin.h"
+#include "ft_lib.h"
+
+static bool	is_whitespace(char c)
+{
+	return (c == ' ' || c == '\t');
+}
+
+bool	ft_legal_number(const char *str, long *result)
+{
+	long	value;
+	char	*endptr;
+	bool	is_strtol_success;
+
+	*result = 0;
+	if (!str)
+		return (false);
+	is_strtol_success = ft_strtol(str, &value, &endptr);
+	if (!is_strtol_success)
+		return (false);
+	while (is_whitespace(*endptr))
+		endptr++;
+	if (*endptr)
+		return (false);
+	*result = value;
+	return (true);
+}

--- a/test/ft_strtol/Makefile
+++ b/test/ft_strtol/Makefile
@@ -1,0 +1,35 @@
+NAME		=	a.out
+
+CC			=	cc
+CFLAGS		=	-Wall -Wextra -Werror -g -fsanitize=address -fsanitize=undefined
+
+SRCS		=	test_strtol.c
+
+OBJS		=	$(SRCS:%.c=%.o)
+
+LIBFT_DIR	= ../../libft
+LIBFT		= $(LIBFT_DIR)/libft.a
+
+all		: $(NAME)
+
+$(NAME)	: $(OBJS)
+	@make -C $(LIBFT_DIR)
+	$(CC) $(CFLAGS) -o $@ $^ $(LIBFT)
+
+$(OBJS)	: $(SRCS)
+	$(CC) $(CFLAGS) -c $^
+
+clean	:
+	$(RM) $(OBJS)
+	@make clean -C $(LIBFT_DIR)
+
+fclean	: clean
+	$(RM) $(NAME)
+	@make fclean -C $(LIBFT_DIR)
+
+re		: fclean all
+
+run		: re
+	./$(NAME)
+
+.PHONY	: all clean fclean re run

--- a/test/ft_strtol/Makefile
+++ b/test/ft_strtol/Makefile
@@ -29,7 +29,7 @@ fclean	: clean
 
 re		: fclean all
 
-run		: re
+run		: all
 	./$(NAME)
 
 .PHONY	: all clean fclean re run

--- a/test/ft_strtol/test_strtol.c
+++ b/test/ft_strtol/test_strtol.c
@@ -1,0 +1,106 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdbool.h>
+#include <limits.h>
+#include <string.h>
+#include <sys/errno.h>
+#include "./../../libft/includes/ft_lib.h"
+#include "./../../libft/includes/ft_ascii.h"
+
+#define COLOR_RED		"\x1b[31m"
+#define COLOR_GREEN		"\x1b[32m"
+#define COLOR_YELLOW	"\x1b[33m"
+#define COLOR_BLUE		"\x1b[34m"
+#define COLOR_MAGENTA	"\x1b[35m"
+#define COLOR_CYAN		"\x1b[36m"
+#define COLOR_RESET		"\x1b[0m"
+
+static char	*get_bool_char(bool b)
+{
+	if (b)
+		return ("true");
+	return ("false");
+}
+
+static char *get_result_char(int res)
+{
+	if (res)
+		return (COLOR_GREEN"OK"COLOR_RESET);
+	return (COLOR_RED"NG"COLOR_RESET);
+}
+
+static int	test(const char *str, int test_no, bool expected_success)
+{
+	long	ft_ret, lib_ret;
+	char	*ft_endptr, *lib_endptr;
+	bool	ft_success, res_endptr;
+
+	ft_success = ft_strtol(str, &ft_ret, &ft_endptr);
+	lib_ret = strtol(str, &lib_endptr, 10);
+	res_endptr = strcmp(ft_endptr, lib_endptr) == 0;
+
+	printf("\n[TEST %02d] '%s'\n", test_no, str);
+	printf(   "            num:%s  lib[%ld]\n", get_result_char(lib_ret == ft_ret), lib_ret);
+	printf(   "                    ft_[%ld]\n", ft_ret);
+	printf(   "            end:%s  lib[%s]\n", get_result_char(res_endptr), lib_endptr);
+	printf(   "                    ft_[%s]\n", ft_endptr);
+	printf(   "            suc:%s  ft_[%s]\n", get_result_char(expected_success == ft_success), get_bool_char(ft_success));
+
+	if (lib_ret == ft_ret && res_endptr && expected_success == ft_success)
+		return (1);
+	return (0);
+}
+
+int	main(void)
+{
+	int	ok_cnt;
+	int	test_no;
+
+	printf("LONG_MAX: \nLONG_MIN: %ld%ld\n", LONG_MAX, LONG_MIN);
+	ok_cnt = 0;
+	test_no = 0;
+
+	printf("===== convert success =====\n");
+	ok_cnt += test("0", ++test_no, true);
+	ok_cnt += test("1", ++test_no, true);
+	ok_cnt += test("-1", ++test_no, true);
+	ok_cnt += test("2147483647", ++test_no, true);
+	ok_cnt += test("-2147483648", ++test_no, true);
+	ok_cnt += test("9223372036854775807", ++test_no, true);
+	ok_cnt += test("-9223372036854775808", ++test_no, true);
+	ok_cnt += test("0000000000", ++test_no, true);
+	ok_cnt += test("+0000000000", ++test_no, true);
+	ok_cnt += test("-000000100", ++test_no, true);
+	ok_cnt += test("   -123", ++test_no, true);
+	ok_cnt += test(" +123", ++test_no, true);
+
+	printf("\n\n===== convert success (must check endptr) =====\n");
+	ok_cnt += test(" +123 ", ++test_no, true);
+	ok_cnt += test("   -123.45", ++test_no, true);
+	ok_cnt += test(" 123 000abc", ++test_no, true);
+
+
+	printf("\n\n===== convert failure (non numeric, over/under flow) =====\n");
+	ok_cnt += test("   - 123", ++test_no, false);
+	ok_cnt += test(" +-123", ++test_no, false);
+	ok_cnt += test("9223372036854775808", ++test_no, false);
+	ok_cnt += test("9223372036854775809", ++test_no, false);
+	ok_cnt += test("9223372036854775809", ++test_no, false);
+	ok_cnt += test("9223372036854775810", ++test_no, false);
+	ok_cnt += test("9223372036854775811", ++test_no, false);
+	ok_cnt += test("9223372036854775812", ++test_no, false);
+	ok_cnt += test("9223372036854775899", ++test_no, false);
+	ok_cnt += test("92233720368547758080", ++test_no, false);
+	ok_cnt += test("92233720368547758081", ++test_no, false);
+	ok_cnt += test("92233720368547758082", ++test_no, false);
+	ok_cnt += test("92233720368547758080123", ++test_no, false);
+	ok_cnt += test("-9223372036854775809", ++test_no, false);
+	ok_cnt += test("92233720368547758080123 ", ++test_no, false);
+	ok_cnt += test("92233720368547758080123abc", ++test_no, false);
+	ok_cnt += test("9223372036854775808012399999999999999999999999999999999999999999999abc", ++test_no, false);
+
+		printf("############################################\n");
+	printf(" TEST RESULT :: OK %d/ ALL %d     %s\n", ok_cnt, test_no, test_no == ok_cnt ? "\x1b[32mALL OK :)\x1b[0m" : "\x1b[31mNG :X\x1b[0m");
+	printf("############################################\n\n");
+	return (0);
+}

--- a/test/legal_number/Makefile
+++ b/test/legal_number/Makefile
@@ -1,0 +1,35 @@
+NAME		=	a.out
+
+CC			=	cc
+CFLAGS		=	-Wall -Wextra -Werror -g -fsanitize=address -fsanitize=undefined
+
+SRCS		=	test_legal_number.c
+
+OBJS		=	$(SRCS:%.c=%.o)
+
+LIBFT_DIR	= ../../libft
+LIBFT		= $(LIBFT_DIR)/libft.a
+
+all		: $(NAME)
+
+$(NAME)	: $(OBJS)
+	@make -C $(LIBFT_DIR)
+	$(CC) $(CFLAGS) -o $@ $^ $(LIBFT)
+
+$(OBJS)	: $(SRCS)
+	$(CC) $(CFLAGS) -c $^
+
+clean	:
+	$(RM) $(OBJS)
+	@make clean -C $(LIBFT_DIR)
+
+fclean	: clean
+	$(RM) $(NAME)
+	@make fclean -C $(LIBFT_DIR)
+
+re		: fclean all
+
+run		: re
+	./$(NAME)
+
+.PHONY	: all clean fclean re run

--- a/test/legal_number/Makefile
+++ b/test/legal_number/Makefile
@@ -29,7 +29,7 @@ fclean	: clean
 
 re		: fclean all
 
-run		: re
+run		: all
 	./$(NAME)
 
 .PHONY	: all clean fclean re run

--- a/test/legal_number/test_legal_number.c
+++ b/test/legal_number/test_legal_number.c
@@ -1,0 +1,98 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdbool.h>
+#include <limits.h>
+#include <string.h>
+#include <sys/errno.h>
+#include "./../../libft/includes/ft_lib.h"
+#include "./../../libft/includes/ft_ascii.h"
+
+#define COLOR_RED		"\x1b[31m"
+#define COLOR_GREEN		"\x1b[32m"
+#define COLOR_YELLOW	"\x1b[33m"
+#define COLOR_BLUE		"\x1b[34m"
+#define COLOR_MAGENTA	"\x1b[35m"
+#define COLOR_CYAN		"\x1b[36m"
+#define COLOR_RESET		"\x1b[0m"
+
+static bool	is_whitespace(char c)
+{
+	return (c == ' ' || c == '\t');
+}
+
+bool	ft_legal_number(const char *str, long *result)
+{
+	long	value;
+	char	*endptr;
+	bool	is_strtol_success;
+
+	*result = 0;
+	if (!str)
+		return (false);
+	is_strtol_success = ft_strtol(str, &value, &endptr);
+	if (!is_strtol_success)
+		return (false);
+	while (is_whitespace(*endptr))
+		endptr++;
+	if (*endptr)
+		return (false);
+	*result = value;
+	return (true);
+}
+
+static char	*get_bool_char(bool b)
+{
+	if (b)
+		return ("true");
+	return ("false");
+}
+
+static char *get_result_char(int res)
+{
+	if (res)
+		return (COLOR_GREEN"OK"COLOR_RESET);
+	return (COLOR_RED"NG"COLOR_RESET);
+}
+
+static int	test(const char *str, long expected_val, bool expected_bool, int test_no)
+{
+	long	res_val;
+	bool	ret_bool;
+
+	ret_bool = ft_legal_number(str, &res_val);
+
+	printf("\n[TEST %02d] '%s'\n", test_no, str);
+	printf(   "            %s : val=[%ld]\n", get_result_char(res_val == expected_val), res_val);
+	printf(   "            %s : ret=[%s]\n", get_result_char(ret_bool == expected_bool), get_bool_char(ret_bool));
+
+	if (ret_bool == expected_bool && res_val == expected_val)
+		return (1);
+	return (0);
+}
+
+int	main(void)
+{
+	int	ok_cnt;
+	int	test_no;
+
+	ok_cnt = 0;
+	test_no = 0;
+
+	printf("===== convert success =====\n");
+	ok_cnt += test(" 0 ", 0, true, ++test_no);
+	ok_cnt += test("    9223372036854775807   ", LONG_MAX, true, ++test_no);
+	ok_cnt += test("   -9223372036854775808 ", LONG_MIN, true, ++test_no);
+	ok_cnt += test("  \n     \r +123\t\t\t\t\t    \t", 123, true, ++test_no);
+
+	printf("\n\n===== convert failure =====\n");
+	ok_cnt += test(" --0 ", 0, false, ++test_no);
+	ok_cnt += test(" 0 \n ", 0, false, ++test_no);
+	ok_cnt += test(" 0  aaa  ", 0, false, ++test_no);
+	ok_cnt += test(" \a 0 ", 0, false, ++test_no);
+	ok_cnt += test(" 123   \v ", 0, false, ++test_no);
+
+	printf("############################################\n");
+	printf(" TEST RESULT :: OK %d/ ALL %d     %s\n", ok_cnt, test_no, test_no == ok_cnt ? "\x1b[32mALL OK :)\x1b[0m" : "\x1b[31mNG :X\x1b[0m");
+	printf("############################################\n\n");
+	return (0);
+}


### PR DESCRIPTION
## ft_strtol
- [x] 実装 ( libft/ft_lib/ft_strtol.c )
- [x] テスト ( test/ft_strtol )

```c
// 正常にlongへ変換できた時にtrue, overflowや不正な引数の場合にはfalseを返す
// strに現れた最初の無効文字のアドレスを*endptrに格納して返す
bool	ft_strtol(const char *str, long *ret_num, char **endptr);
```

<br>

## ft_legal_number
- [x] 実装 ( builtin/ft_legal_number.c )
- [x] テスト ( test/legal_number )
```c
// exitの引数をparseし、有効な引数であればtrue, 無効であればfalseを返す
// parseした引数はresultに格納する
bool	ft_legal_number(const char *str, long *result)
```