### PR TITLE
fix path of `make norm`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ sani	:
 
 .PHONY	: norm
 norm	: all
-	python3 .github/sh/norm.py
+	python3 ./test/integration_test/norm.py
 
 
 #--------------------------------------------


### PR DESCRIPTION
make norm で指定するpython fileのpathが `.github/sh/norm.py`のままだった...
変更 -> https://github.com/habvi/42_minishell/pull/101/commits/fdfbfcf779f3ae51c479347a7ec070f4efc91ead