### PR TITLE
add(playground): test of chdir

### DIFF
--- a/playground/ta/.gitignore
+++ b/playground/ta/.gitignore
@@ -5,5 +5,4 @@
 !*.sh
 !*.md
 !parser_test/
-!parser_pipe/
-!parser_pipe/**
+!chdir/

--- a/playground/ta/chdir/test_chdir.c
+++ b/playground/ta/chdir/test_chdir.c
@@ -1,0 +1,18 @@
+#include <stdio.h>
+#include <unistd.h>
+
+int	main(void)
+{
+
+	chdir("/bin");// todo : move to /usr/bin with chdir("/bin") ??
+
+	printf("path:%s\n", getcwd(NULL, 0));
+
+	char *cmd[] = {"/bin/pwd", NULL};
+	execve(cmd[0], cmd, NULL);
+
+//	char *cmd[] = {"/bin/ls", NULL};
+//	execve(cmd[0], cmd, NULL);
+
+	return (0);
+}


### PR DESCRIPTION
* chdirのテストを追加 (`@playground/ta/chdir/`)
* `chdir("/bin")` で ubuntuは`/usr/bin`へ、macは`/bin`へ移動した...🙄
  -> ubuntuは`/bin`が`/usr/bin`へのシンボリックリンクになっているからでした
```
$ ls -l
...
lrwxrwxrwx   1 root root          7 Feb 18 02:22  bin -> usr/bin
...
```