### PR TITLE
add: deque_pop_selected_node

### DIFF
--- a/libft/Makefile
+++ b/libft/Makefile
@@ -23,6 +23,7 @@ DEQUE_SRC	:=	$(DEQUE_DIR)/dq_add_back.c \
 				$(DEQUE_DIR)/dq_node_new.c \
 				$(DEQUE_DIR)/dq_pop_back.c \
 				$(DEQUE_DIR)/dq_pop_front.c \
+				$(DEQUE_DIR)/dq_pop_selected_node.c \
 				$(DEQUE_DIR)/dq_print.c \
 				$(DEQUE_DIR)/dq_set_node.c
 

--- a/libft/includes/ft_deque.h
+++ b/libft/includes/ft_deque.h
@@ -31,6 +31,8 @@ bool			deque_is_empty(t_deque *deque);
 t_deque_node	*deque_pop_back(t_deque *deque);
 t_deque_node	*deque_pop_last_node(t_deque *deque);
 t_deque_node	*deque_pop_front(t_deque *deque);
+void			deque_pop_selected_node(t_deque *deque, \
+										t_deque_node *target_node);
 
 /* print */
 void			deque_print(t_deque *deque);

--- a/libft/srcs/ft_deque/dq_pop_selected_node.c
+++ b/libft/srcs/ft_deque/dq_pop_selected_node.c
@@ -1,0 +1,24 @@
+#include "ft_deque.h"
+
+static void	pop_target_node(t_deque *deque, t_deque_node *node)
+{
+	(void)deque;
+	(void)node;
+}
+void	deque_pop_selected_node(t_deque *deque, t_deque_node *target_node)
+{
+	t_deque_node	*node;
+
+	if (!deque || !target_node)
+		return ;
+	node = deque->node;
+	while (node)
+	{
+		if (node == target_node)
+		{
+			pop_target_node(deque, target_node);
+			return ;
+		}
+		node = node->next;
+	}
+}

--- a/libft/srcs/ft_deque/dq_pop_selected_node.c
+++ b/libft/srcs/ft_deque/dq_pop_selected_node.c
@@ -1,10 +1,41 @@
 #include "ft_deque.h"
 
+static bool	is_head_node(t_deque *deque, t_deque_node *node)
+{
+	return (deque->node == node);
+}
+
+static bool	is_tail_node(t_deque *deque, t_deque_node *node)
+{
+	return (deque->node->prev == node);
+}
+
 static void	pop_target_node(t_deque *deque, t_deque_node *node)
 {
-	(void)deque;
-	(void)node;
+	t_deque_node	*left_node;
+	t_deque_node	*right_node;
+
+	if (deque->size == 1)
+	{
+		deque_pop_last_node(deque);
+		return ;
+	}
+	if (is_head_node(deque, node))
+		deque_pop_front(deque);
+	else if (is_tail_node(deque, node))
+		deque_pop_back(deque);
+	else
+	{
+		left_node = node->prev;
+		right_node = node->next;
+		deque_set_next(node, NULL);
+		deque_set_prev(node, NULL);
+		deque_set_next(left_node, right_node);
+		deque_set_prev(right_node, left_node);
+		deque->size--;
+	}
 }
+
 void	deque_pop_selected_node(t_deque *deque, t_deque_node *target_node)
 {
 	t_deque_node	*node;

--- a/test/unit_test/deque/test.c
+++ b/test/unit_test/deque/test.c
@@ -79,6 +79,29 @@ static void	pop_front_test(t_deque *deque)
 	debug_deque_print(deque, __func__);
 }
 
+static void	pop_selected_node_test(t_deque *deque, size_t idx)
+{
+	t_deque_node	*pop_node = deque->node;
+	size_t			i;
+
+	if (!deque_is_empty(deque))
+	{
+		i = 0;
+		while (pop_node && i < idx)
+		{
+			pop_node = pop_node->next;
+			i++;
+		}
+	}
+	deque_pop_selected_node(deque, pop_node);
+	if (pop_node)
+	{
+		printf("pop_selected success: %s\n", (char *)pop_node->content);
+		deque_clear_node(&pop_node);
+	}
+	debug_deque_print(deque, __func__);
+}
+
 char *get_s(char c)
 {
 	char	*s;
@@ -126,6 +149,23 @@ int	main(void)
 	pop_front_test(deque);
 	pop_front_test(deque);
 	pop_front_test(deque);
+
+	add_front_test(deque, get_s('c'));
+	add_front_test(deque, get_s('b'));
+	add_front_test(deque, get_s('a'));
+
+	pop_selected_node_test(deque, 1);
+
+	add_front_test(deque, get_s('d'));
+	add_front_test(deque, get_s('e'));
+	add_front_test(deque, get_s('f'));
+
+	pop_selected_node_test(deque, 1);
+	pop_selected_node_test(deque, 3);
+	pop_selected_node_test(deque, 0);
+	pop_selected_node_test(deque, 1);
+	pop_selected_node_test(deque, 0);
+	pop_selected_node_test(deque, 0);
 
 	deque_clear_all(&deque);
 	return (EXIT_SUCCESS);


### PR DESCRIPTION
Issue #122 (PR #129 ) の hash 作成中に必要になった libft/srcs/ft_deque/ の関数。

`t_deque_node *` のアドレスを指定して、それが `t_deque *` 内にあれば pop する (free はしない) 関数を追加。
deque から見つからなければ今のところ何もしない。
```c
void deque_pop_selected_node(t_deque *deque, t_deque_node *target_node);
```

`t_hash` 内の `t_deque **table` で主に使う。
`table[i]` の deque の要素数 (t_deque_node) が 0 になっても外側で作られた `t_deque *` だけは残り、この関数では関与していない。