### PR TITLE
fix deque_clear_all

### DIFF
--- a/libft/srcs/ft_deque/dq_clear_all.c
+++ b/libft/srcs/ft_deque/dq_clear_all.c
@@ -9,6 +9,7 @@ void	deque_clear_all(t_deque **deque)
 	if (deque_is_empty(*deque))
 	{
 		free(*deque);
+		*deque = NULL;
 		return ;
 	}
 	node = (*deque)->node;


### PR DESCRIPTION
Issue #122 (PR #129 ) の hash 作成中の修正。
先頭の `t_deque` のみ (`t_deque_node` が 0 ) の時に free 後 NULL を入れるようにする。