### PR TITLE
clear_hash_elem

### DIFF
--- a/libft/includes/ft_hash.h
+++ b/libft/includes/ft_hash.h
@@ -47,7 +47,7 @@ void		update_content_of_key(t_hash *hash, char *key, void *content);
 
 /* clear table */
 void		del(void *content);
-void		clear_hash_elem(t_elem **elem, void (*del)(void *))
+void		clear_hash_elem(t_elem **elem, void (*del)(void *));
 void		clear_hash_table(t_hash **hash);
 
 /* display hash table */

--- a/libft/includes/ft_hash.h
+++ b/libft/includes/ft_hash.h
@@ -46,7 +46,8 @@ void		update_content_of_key(t_hash *hash, char *key, void *content);
 /* del key */
 
 /* clear table */
-//void		clear_hash_elem(t_elem **elem, void (*del)(void *))
+void		del(void *content);
+void		clear_hash_elem(t_elem **elem, void (*del)(void *))
 void		clear_hash_table(t_hash **hash);
 
 /* display hash table */

--- a/libft/srcs/ft_hash/clear_hash_table.c
+++ b/libft/srcs/ft_hash/clear_hash_table.c
@@ -2,15 +2,22 @@
 #include "ft_deque.h"
 #include "ft_hash.h"
 
-//void	clear_hash_elem(t_elem **elem, void (*del)(void *))
-//{
-//	if (!elem || !*elem)
-//		return ;
-//	free((*elem)->key);
-//	del((*elem)->content);
-//	free(*elem);
-//	*elem = NULL;
-//}
+void	del(void *content)
+{
+	free(content);
+}
+
+void	clear_hash_elem(t_elem **elem, void (*del)(void *))
+{
+	if (!elem || !*elem)
+		return ;
+	free((*elem)->key);
+	(*elem)->key = NULL;
+	del((*elem)->content);
+	(*elem)->content = NULL;
+	free(*elem);
+	*elem = NULL;
+}
 
 void	clear_hash_table(t_hash **hash)
 {
@@ -22,7 +29,7 @@ void	clear_hash_table(t_hash **hash)
 	while (idx < (*hash)->table_size)
 	{
 		if ((*hash)->table[idx])
-			deque_clear_all(&(*hash)->table[idx]); // TODO: del(content)
+			deque_clear_all(&(*hash)->table[idx]); // TODO: clear_hash_elem
 		idx++;
 	}
 	free((*hash)->table);

--- a/libft/srcs/ft_hash/set_key_to_table.c
+++ b/libft/srcs/ft_hash/set_key_to_table.c
@@ -56,10 +56,7 @@ int	set_to_table(t_hash *hash, char *key, void *content)
 		//todo:rehash
 		if (add_elem_to_table(hash, elem) == HASH_ERROR)
 		{
-			free(key);
-			// todo: del func
-			free(content);
-			free(elem);
+			clear_hash_elem(&elem, del);
 			return (HASH_ERROR);
 		}
 		hash->key_count++;


### PR DESCRIPTION
試しに今の段階での clear_hash_elem を作ってみたら大量のエラーが…
それを見て欲しいが為の draft branch。
```
includes/ft_hash.h:51:7: error: old-style parameter declarations in prototyped function definition
 void  clear_hash_elem(t_elem **elem, void (*del)(void *))
```