### PR TITLE
update hash

### DIFF
--- a/libft/includes/ft_hash.h
+++ b/libft/includes/ft_hash.h
@@ -50,9 +50,9 @@ void			update_content_of_key(char **key, \
 /* del key */
 
 /* clear table */
-void		del(void *content);
-void		clear_hash_elem(t_elem **elem, void (*del)(void *));
-void		clear_hash_table(t_hash **hash);
+void			del(void *content);
+void			clear_hash_elem(t_elem **elem, void (*del)(void *));
+void			clear_hash_table(t_hash **hash);
 
 /* display hash table */
 void			display_hash_table(t_hash *hash, void (*display)(void *));

--- a/libft/includes/ft_hash.h
+++ b/libft/includes/ft_hash.h
@@ -36,7 +36,7 @@ t_hash		*create_hash_table(uint64_t size);
 int			set_to_table(t_hash *hash, char *key, void *content);
 
 /* find key */
-bool		find_key(t_hash *hash, const char *key);
+t_deque_node	*find_key(t_hash *hash, const char *key);
 
 /* get value */
 

--- a/libft/includes/ft_hash.h
+++ b/libft/includes/ft_hash.h
@@ -41,7 +41,9 @@ t_deque_node	*find_key(t_hash *hash, const char *key);
 /* get value */
 
 /* update value */
-void		update_content_of_key(t_hash *hash, char *key, void *content);
+void	update_content_of_key(char **key, \
+								void *content, \
+								t_deque_node *target_node);
 
 /* del key */
 

--- a/libft/includes/ft_hash.h
+++ b/libft/includes/ft_hash.h
@@ -24,16 +24,17 @@ typedef struct s_hash_element
 }	t_elem;
 
 /* hash value */
-uint64_t	generate_fnv_hash_64(const unsigned char *key, uint64_t hash_mod);
+uint64_t		generate_fnv_hash_64(const unsigned char *key, \
+										uint64_t hash_mod);
 
 /* generate hash table */
 // return a pointer to the hash table. On error, return NULL
-t_hash		*create_hash_table(uint64_t size);
+t_hash			*create_hash_table(uint64_t size);
 
 /* add key */
 // add key-value pairs to table and return 0. On error, return (-1)
 // if hash_value conflicts, add with the chain method
-int			set_to_table(t_hash *hash, char *key, void *content);
+int				set_to_table(t_hash *hash, char *key, void *content);
 
 /* find key */
 t_deque_node	*find_key(t_hash *hash, const char *key);
@@ -41,17 +42,17 @@ t_deque_node	*find_key(t_hash *hash, const char *key);
 /* get value */
 
 /* update value */
-void	update_content_of_key(char **key, \
-								void *content, \
-								t_deque_node *target_node);
+void			update_content_of_key(char **key, \
+										void *content, \
+										t_deque_node *target_node);
 
 /* del key */
 
 /* clear table */
-//void		clear_hash_elem(t_elem **elem, void (*del)(void *))
-void		clear_hash_table(t_hash **hash);
+//void			clear_hash_elem(t_elem **elem, void (*del)(void *))
+void			clear_hash_table(t_hash **hash);
 
 /* display hash table */
-void		display_hash_table(t_hash *hash, void (*display)(void *));
+void			display_hash_table(t_hash *hash, void (*display)(void *));
 
 #endif //FT_HASH_H

--- a/libft/includes/ft_hash.h
+++ b/libft/includes/ft_hash.h
@@ -8,7 +8,8 @@
 # define HASH_SUCCESS	0
 # define HASH_ERROR		(-1)
 
-typedef struct s_deque	t_deque;
+typedef struct s_deque_node	t_deque_node;
+typedef struct s_deque		t_deque;
 
 typedef struct s_hash_table
 {

--- a/libft/includes/ft_hash.h
+++ b/libft/includes/ft_hash.h
@@ -49,8 +49,9 @@ void			update_content_of_key(char **key, \
 /* del key */
 
 /* clear table */
-//void			clear_hash_elem(t_elem **elem, void (*del)(void *))
-void			clear_hash_table(t_hash **hash);
+void		del(void *content);
+void		clear_hash_elem(t_elem **elem, void (*del)(void *));
+void		clear_hash_table(t_hash **hash);
 
 /* display hash table */
 void			display_hash_table(t_hash *hash, void (*display)(void *));

--- a/libft/srcs/ft_deque/dq_clear_all.c
+++ b/libft/srcs/ft_deque/dq_clear_all.c
@@ -9,6 +9,7 @@ void	deque_clear_all(t_deque **deque)
 	if (deque_is_empty(*deque))
 	{
 		free(*deque);
+		*deque = NULL;
 		return ;
 	}
 	node = (*deque)->node;

--- a/libft/srcs/ft_hash/clear_hash_table.c
+++ b/libft/srcs/ft_hash/clear_hash_table.c
@@ -26,6 +26,7 @@ void	clear_hash_table(t_hash **hash)
 		idx++;
 	}
 	free((*hash)->table);
+	(*hash)->table = NULL;
 	free(*hash);
 	*hash = NULL;
 }

--- a/libft/srcs/ft_hash/clear_hash_table.c
+++ b/libft/srcs/ft_hash/clear_hash_table.c
@@ -2,15 +2,22 @@
 #include "ft_deque.h"
 #include "ft_hash.h"
 
-//void	clear_hash_elem(t_elem **elem, void (*del)(void *))
-//{
-//	if (!elem || !*elem)
-//		return ;
-//	free((*elem)->key);
-//	del((*elem)->content);
-//	free(*elem);
-//	*elem = NULL;
-//}
+void	del(void *content)
+{
+	free(content);
+}
+
+void	clear_hash_elem(t_elem **elem, void (*del)(void *))
+{
+	if (!elem || !*elem)
+		return ;
+	free((*elem)->key);
+	(*elem)->key = NULL;
+	del((*elem)->content);
+	(*elem)->content = NULL;
+	free(*elem);
+	*elem = NULL;
+}
 
 void	clear_hash_table(t_hash **hash)
 {
@@ -22,7 +29,7 @@ void	clear_hash_table(t_hash **hash)
 	while (idx < (*hash)->table_size)
 	{
 		if ((*hash)->table[idx])
-			deque_clear_all(&(*hash)->table[idx]); // TODO: del(content)
+			deque_clear_all(&(*hash)->table[idx]); // TODO: clear_hash_elem
 		idx++;
 	}
 	free((*hash)->table);

--- a/libft/srcs/ft_hash/create_hash_table.c
+++ b/libft/srcs/ft_hash/create_hash_table.c
@@ -14,6 +14,10 @@ t_hash	*create_hash_table(uint64_t size)
 	hash->key_count = 0;
 	hash->table = (t_deque **)ft_calloc(hash->table_size, sizeof(t_deque *));
 	if (!hash->table)
+	{
+		free(hash);
+		hash = NULL;
 		return (NULL);
+	}
 	return (hash);
 }

--- a/libft/srcs/ft_hash/display_hash_table.c
+++ b/libft/srcs/ft_hash/display_hash_table.c
@@ -13,6 +13,8 @@ static void	print_table_elem(t_deque *deque, void (*display)(void *))
 {
 	t_deque_node	*node;
 
+	if (!deque)
+		return ;
 	node = deque->node;
 	while (node)
 	{

--- a/libft/srcs/ft_hash/find_key_from_table.c
+++ b/libft/srcs/ft_hash/find_key_from_table.c
@@ -6,6 +6,8 @@ static bool	is_key_in_deque(t_deque_node *node, const char *key)
 {
 	t_elem	*elem;
 
+	if (!node || !key)
+		return (NULL);
 	while (node)
 	{
 		elem = (t_elem *)node->content;

--- a/libft/srcs/ft_hash/find_key_from_table.c
+++ b/libft/srcs/ft_hash/find_key_from_table.c
@@ -2,7 +2,7 @@
 #include "ft_hash.h"
 #include "ft_string.h"
 
-static bool	is_key_in_deque(t_deque_node *node, const char *key)
+static t_deque_node	*find_key_in_deque(t_deque_node *node, const char *key)
 {
 	t_elem	*elem;
 
@@ -12,25 +12,25 @@ static bool	is_key_in_deque(t_deque_node *node, const char *key)
 	{
 		elem = (t_elem *)node->content;
 		if (ft_streq(elem->key, key))
-			return (true);
+			return (node);
 		node = node->next;
 	}
-	return (false);
+	return (NULL);
 }
 
-// return true if key is in table
-bool	find_key(t_hash *hash, const char *key)
+// if key is in table return t_deque_node's addr, else NULL
+t_deque_node	*find_key(t_hash *hash, const char *key)
 {
-	uint64_t	hash_val;
-	bool		result;
+	uint64_t		hash_val;
+	t_deque_node	*result;
 
 	if (!hash || !key)
-		return (false);
+		return (NULL);
 	hash_val = generate_fnv_hash_64((unsigned char *)key, hash->table_size);
 	if (!hash->table[hash_val])
-		return (false);
+		return (NULL);
 	if (!hash->table[hash_val]->size)
-		return (false);
-	result = is_key_in_deque(hash->table[hash_val]->node, key);
+		return (NULL);
+	result = find_key_in_deque(hash->table[hash_val]->node, key);
 	return (result);
 }

--- a/libft/srcs/ft_hash/set_key_to_table.c
+++ b/libft/srcs/ft_hash/set_key_to_table.c
@@ -60,8 +60,7 @@ int	set_to_table(t_hash *hash, char *key, void *content)
 		{
 			// clear_hash_elem
 			free(key);
-			// todo: del func
-			free(content);
+			free(content); // todo: del func
 			free(elem);
 			return (HASH_ERROR);
 		}

--- a/libft/srcs/ft_hash/set_key_to_table.c
+++ b/libft/srcs/ft_hash/set_key_to_table.c
@@ -58,10 +58,7 @@ int	set_to_table(t_hash *hash, char *key, void *content)
 		//todo:rehash
 		if (add_elem_to_table(hash, elem) == HASH_ERROR)
 		{
-			// clear_hash_elem
-			free(key);
-			free(content); // todo: del func
-			free(elem);
+			clear_hash_elem(&elem, del);
 			return (HASH_ERROR);
 		}
 		hash->key_count++;

--- a/libft/srcs/ft_hash/set_key_to_table.c
+++ b/libft/srcs/ft_hash/set_key_to_table.c
@@ -42,12 +42,14 @@ static int	add_elem_to_table(t_hash *hash, t_elem *elem)
 // 'key' cannot be null, 'value' can accept null
 int	set_to_table(t_hash *hash, char *key, void *content)
 {
-	t_elem	*elem;
+	t_elem			*elem;
+	t_deque_node	*target_node;
 
 	if (!key)
 		return (HASH_SUCCESS);
-	if (find_key(hash, key))
-		update_content_of_key(hash, key, content);
+	target_node = find_key(hash, key);
+	if (target_node)
+		update_content_of_key(&key, content, target_node);
 	else
 	{
 		elem = create_hash_elem(key, content);

--- a/libft/srcs/ft_hash/set_key_to_table.c
+++ b/libft/srcs/ft_hash/set_key_to_table.c
@@ -56,6 +56,7 @@ int	set_to_table(t_hash *hash, char *key, void *content)
 		//todo:rehash
 		if (add_elem_to_table(hash, elem) == HASH_ERROR)
 		{
+			// clear_hash_elem
 			free(key);
 			// todo: del func
 			free(content);

--- a/libft/srcs/ft_hash/update_value.c
+++ b/libft/srcs/ft_hash/update_value.c
@@ -1,29 +1,14 @@
 #include <stdlib.h>
 #include "ft_deque.h"
-#include "ft_hash.h"
-#include "ft_string.h"
 
 // key exist in hash
 // free(key, pre-content), update new content
-void	update_content_of_key(t_hash *hash, char *key, void *content)
+void	update_content_of_key(char **key, \
+								void *content, \
+								t_deque_node *target_node)
 {
-	uint64_t		hash_val;
-	t_deque_node	*node;
-	t_elem			*elem;
-
-	hash_val = generate_fnv_hash_64((unsigned char *)key, hash->table_size);
-	node = hash->table[hash_val]->node;
-	while (node)
-	{
-		elem = (t_elem *)node->content;
-		if (ft_streq(elem->key, key))
-		{
-			free(key);
-			// todo: del func
-			free(node->content);
-			node->content = content;
-			return ;
-		}
-		node = node->next;
-	}
+	free(*key);
+	*key = NULL;
+	free(target_node->content);
+	target_node->content = content;
 }

--- a/libft/srcs/ft_hash/update_value.c
+++ b/libft/srcs/ft_hash/update_value.c
@@ -1,5 +1,6 @@
 #include <stdlib.h>
 #include "ft_deque.h"
+#include "ft_hash.h"
 
 // key exist in hash
 // free(key, pre-content), update new content
@@ -7,8 +8,12 @@ void	update_content_of_key(char **key, \
 								void *content, \
 								t_deque_node *target_node)
 {
-	free(*key);
-	*key = NULL;
-	free(target_node->content);
-	target_node->content = content;
+	t_elem	*elem;
+
+	(void)key;
+	// free(*key);
+	// *key = NULL;
+	elem = (t_elem *)target_node->content;
+	// free(elem->content);
+	elem->content = content;
 }

--- a/test/unit_test/hash/test_hash.c
+++ b/test/unit_test/hash/test_hash.c
@@ -65,26 +65,26 @@ int	main(void)
 		t_hash	*hash = create_hash_table(100);
 		display_hash_table(hash, display_elem);
 
-		add_to_table(hash, "test_key", "test_value");
-		add_to_table(hash, "pien", ";p");
-		add_to_table(hash, "PATH", "/bin:/usr/bin:etc");
+		set_to_table(hash, "test_key", "test_value");
+		set_to_table(hash, "pien", ";p");
+		set_to_table(hash, "PATH", "/bin:/usr/bin:etc");
 		display_table_info(hash);
 
-		add_to_table(hash, "empty string", "");
+		set_to_table(hash, "empty string", "");
 		display_table_info(hash);
 
-		add_to_table(hash, "empty value", NULL);
+		set_to_table(hash, "empty value", NULL);
 		display_table_info(hash);
 
-		add_to_table(hash, "PATHa", "/bin:/usr/bin:etc");
-		add_to_table(hash, "PATH1", "/bin:/usr/bin:etc1");
+		set_to_table(hash, "PATHa", "/bin:/usr/bin:etc");
+		set_to_table(hash, "PATH1", "/bin:/usr/bin:etc1");
 		display_table_info(hash);
 
-		add_to_table(hash, "abc", "abc1");
-		add_to_table(hash, "abc", "abc2");
-		add_to_table(hash, "abc", "abc3");
-		add_to_table(hash, "abc", "abc4");
-		add_to_table(hash, "abc", "abc5");
+		set_to_table(hash, "abc", "abc1");
+		set_to_table(hash, "abc", "abc2");
+		set_to_table(hash, "abc", "abc3");
+		set_to_table(hash, "abc", "abc4");
+		set_to_table(hash, "abc", "abc5");
 		display_table_info(hash);
 
 		clear_hash_table(&hash);


### PR DESCRIPTION
Issue #122 (PR #129 ) の hash 作成中の修正。(branch name が内容と合ってません…)

`libft/deque_clear_all` 
- [x] 先頭の `t_deque` のみ (`t_deque_node` が 0 ) の時に free 後 NULL を入れるようにする。

`ft_hash/`
- [x] malloc error 時の free 関係追加
- [x] find_key が deque node を返すと便利なので試しに変更してみました(戻すでもok)
- [x] ↑ のおかげで update_content が target_node を見るだけで loop を回さなくて済むように
- [x] display_hash : NULL return