### PR TITLE
hash use allocated str

### DIFF
--- a/libft/includes/ft_hash.h
+++ b/libft/includes/ft_hash.h
@@ -50,9 +50,9 @@ void			update_content_of_key(char **key, \
 /* del key */
 
 /* clear table */
-void		del(void *content);
-void		clear_hash_elem(t_elem **elem, void (*del)(void *));
-void		clear_hash_table(t_hash **hash);
+void			del(void *content);
+void			clear_hash_elem(t_elem **elem, void (*del)(void *));
+void			clear_hash_table(t_hash **hash);
 
 /* display hash table */
 void			display_hash_table(t_hash *hash, void (*display)(void *));

--- a/libft/includes/ft_hash.h
+++ b/libft/includes/ft_hash.h
@@ -36,7 +36,7 @@ t_hash		*create_hash_table(uint64_t size);
 int			set_to_table(t_hash *hash, char *key, void *content);
 
 /* find key */
-bool		find_key(t_hash *hash, const char *key);
+t_deque_node	*find_key(t_hash *hash, const char *key);
 
 /* get value */
 

--- a/libft/includes/ft_hash.h
+++ b/libft/includes/ft_hash.h
@@ -41,7 +41,9 @@ t_deque_node	*find_key(t_hash *hash, const char *key);
 /* get value */
 
 /* update value */
-void		update_content_of_key(t_hash *hash, char *key, void *content);
+void	update_content_of_key(char **key, \
+								void *content, \
+								t_deque_node *target_node);
 
 /* del key */
 

--- a/libft/includes/ft_hash.h
+++ b/libft/includes/ft_hash.h
@@ -24,16 +24,17 @@ typedef struct s_hash_element
 }	t_elem;
 
 /* hash value */
-uint64_t	generate_fnv_hash_64(const unsigned char *key, uint64_t hash_mod);
+uint64_t		generate_fnv_hash_64(const unsigned char *key, \
+										uint64_t hash_mod);
 
 /* generate hash table */
 // return a pointer to the hash table. On error, return NULL
-t_hash		*create_hash_table(uint64_t size);
+t_hash			*create_hash_table(uint64_t size);
 
 /* add key */
 // add key-value pairs to table and return 0. On error, return (-1)
 // if hash_value conflicts, add with the chain method
-int			set_to_table(t_hash *hash, char *key, void *content);
+int				set_to_table(t_hash *hash, char *key, void *content);
 
 /* find key */
 t_deque_node	*find_key(t_hash *hash, const char *key);
@@ -41,17 +42,17 @@ t_deque_node	*find_key(t_hash *hash, const char *key);
 /* get value */
 
 /* update value */
-void	update_content_of_key(char **key, \
-								void *content, \
-								t_deque_node *target_node);
+void			update_content_of_key(char **key, \
+										void *content, \
+										t_deque_node *target_node);
 
 /* del key */
 
 /* clear table */
-//void		clear_hash_elem(t_elem **elem, void (*del)(void *))
-void		clear_hash_table(t_hash **hash);
+//void			clear_hash_elem(t_elem **elem, void (*del)(void *))
+void			clear_hash_table(t_hash **hash);
 
 /* display hash table */
-void		display_hash_table(t_hash *hash, void (*display)(void *));
+void			display_hash_table(t_hash *hash, void (*display)(void *));
 
 #endif //FT_HASH_H

--- a/libft/includes/ft_hash.h
+++ b/libft/includes/ft_hash.h
@@ -8,7 +8,8 @@
 # define HASH_SUCCESS	0
 # define HASH_ERROR		(-1)
 
-typedef struct s_deque	t_deque;
+typedef struct s_deque_node	t_deque_node;
+typedef struct s_deque		t_deque;
 
 typedef struct s_hash_table
 {

--- a/libft/includes/ft_hash.h
+++ b/libft/includes/ft_hash.h
@@ -49,8 +49,9 @@ void			update_content_of_key(char **key, \
 /* del key */
 
 /* clear table */
-//void			clear_hash_elem(t_elem **elem, void (*del)(void *))
-void			clear_hash_table(t_hash **hash);
+void		del(void *content);
+void		clear_hash_elem(t_elem **elem, void (*del)(void *));
+void		clear_hash_table(t_hash **hash);
 
 /* display hash table */
 void			display_hash_table(t_hash *hash, void (*display)(void *));

--- a/libft/srcs/ft_deque/dq_clear_all.c
+++ b/libft/srcs/ft_deque/dq_clear_all.c
@@ -9,6 +9,7 @@ void	deque_clear_all(t_deque **deque)
 	if (deque_is_empty(*deque))
 	{
 		free(*deque);
+		*deque = NULL;
 		return ;
 	}
 	node = (*deque)->node;

--- a/libft/srcs/ft_hash/clear_hash_table.c
+++ b/libft/srcs/ft_hash/clear_hash_table.c
@@ -26,6 +26,7 @@ void	clear_hash_table(t_hash **hash)
 		idx++;
 	}
 	free((*hash)->table);
+	(*hash)->table = NULL;
 	free(*hash);
 	*hash = NULL;
 }

--- a/libft/srcs/ft_hash/clear_hash_table.c
+++ b/libft/srcs/ft_hash/clear_hash_table.c
@@ -2,15 +2,22 @@
 #include "ft_deque.h"
 #include "ft_hash.h"
 
-//void	clear_hash_elem(t_elem **elem, void (*del)(void *))
-//{
-//	if (!elem || !*elem)
-//		return ;
-//	free((*elem)->key);
-//	del((*elem)->content);
-//	free(*elem);
-//	*elem = NULL;
-//}
+void	del(void *content)
+{
+	free(content);
+}
+
+void	clear_hash_elem(t_elem **elem, void (*del)(void *))
+{
+	if (!elem || !*elem)
+		return ;
+	free((*elem)->key);
+	(*elem)->key = NULL;
+	del((*elem)->content);
+	(*elem)->content = NULL;
+	free(*elem);
+	*elem = NULL;
+}
 
 void	clear_hash_table(t_hash **hash)
 {
@@ -22,7 +29,7 @@ void	clear_hash_table(t_hash **hash)
 	while (idx < (*hash)->table_size)
 	{
 		if ((*hash)->table[idx])
-			deque_clear_all(&(*hash)->table[idx]); // TODO: del(content)
+			deque_clear_all(&(*hash)->table[idx]); // TODO: clear_hash_elem
 		idx++;
 	}
 	free((*hash)->table);

--- a/libft/srcs/ft_hash/clear_hash_table.c
+++ b/libft/srcs/ft_hash/clear_hash_table.c
@@ -19,6 +19,49 @@ void	clear_hash_elem(t_elem **elem, void (*del)(void *))
 	*elem = NULL;
 }
 
+// todo: use func pointer?
+static void	tmp_deque_clear_node(t_deque_node **node)
+{
+	t_elem	*elem;
+
+	if (!*node)
+		return ;
+	elem = (*node)->content;
+	free(elem->key);
+	elem->key = NULL;
+	free(elem->content);
+	elem->content = NULL;
+	free(elem);
+	elem = NULL;
+	(*node)->next = NULL;
+	(*node)->prev = NULL;
+	free(*node);
+	*node = NULL;
+}
+
+// todo: use func pointer?
+static void	tmp_deque_clear_all(t_deque **deque)
+{
+	t_deque_node	*node;
+	t_deque_node	*tmp;
+
+	if (deque_is_empty(*deque))
+	{
+		free(*deque);
+		*deque = NULL;
+		return ;
+	}
+	node = (*deque)->node;
+	while (node)
+	{
+		tmp = node;
+		node = node->next;
+		tmp_deque_clear_node(&tmp);
+	}
+	free(*deque);
+	*deque = NULL;
+}
+
 void	clear_hash_table(t_hash **hash)
 {
 	size_t	idx;
@@ -29,7 +72,10 @@ void	clear_hash_table(t_hash **hash)
 	while (idx < (*hash)->table_size)
 	{
 		if ((*hash)->table[idx])
-			deque_clear_all(&(*hash)->table[idx]); // TODO: clear_hash_elem
+		{
+			// deque_clear_all(&(*hash)->table[idx]); // TODO: clear_hash_elem
+			tmp_deque_clear_all(&(*hash)->table[idx]);
+		}
 		idx++;
 	}
 	free((*hash)->table);

--- a/libft/srcs/ft_hash/create_hash_table.c
+++ b/libft/srcs/ft_hash/create_hash_table.c
@@ -14,6 +14,10 @@ t_hash	*create_hash_table(uint64_t size)
 	hash->key_count = 0;
 	hash->table = (t_deque **)ft_calloc(hash->table_size, sizeof(t_deque *));
 	if (!hash->table)
+	{
+		free(hash);
+		hash = NULL;
 		return (NULL);
+	}
 	return (hash);
 }

--- a/libft/srcs/ft_hash/display_hash_table.c
+++ b/libft/srcs/ft_hash/display_hash_table.c
@@ -13,6 +13,8 @@ static void	print_table_elem(t_deque *deque, void (*display)(void *))
 {
 	t_deque_node	*node;
 
+	if (!deque)
+		return ;
 	node = deque->node;
 	while (node)
 	{

--- a/libft/srcs/ft_hash/find_key_from_table.c
+++ b/libft/srcs/ft_hash/find_key_from_table.c
@@ -6,6 +6,8 @@ static bool	is_key_in_deque(t_deque_node *node, const char *key)
 {
 	t_elem	*elem;
 
+	if (!node || !key)
+		return (NULL);
 	while (node)
 	{
 		elem = (t_elem *)node->content;

--- a/libft/srcs/ft_hash/find_key_from_table.c
+++ b/libft/srcs/ft_hash/find_key_from_table.c
@@ -2,7 +2,7 @@
 #include "ft_hash.h"
 #include "ft_string.h"
 
-static bool	is_key_in_deque(t_deque_node *node, const char *key)
+static t_deque_node	*find_key_in_deque(t_deque_node *node, const char *key)
 {
 	t_elem	*elem;
 
@@ -12,25 +12,25 @@ static bool	is_key_in_deque(t_deque_node *node, const char *key)
 	{
 		elem = (t_elem *)node->content;
 		if (ft_streq(elem->key, key))
-			return (true);
+			return (node);
 		node = node->next;
 	}
-	return (false);
+	return (NULL);
 }
 
-// return true if key is in table
-bool	find_key(t_hash *hash, const char *key)
+// if key is in table return t_deque_node's addr, else NULL
+t_deque_node	*find_key(t_hash *hash, const char *key)
 {
-	uint64_t	hash_val;
-	bool		result;
+	uint64_t		hash_val;
+	t_deque_node	*result;
 
 	if (!hash || !key)
-		return (false);
+		return (NULL);
 	hash_val = generate_fnv_hash_64((unsigned char *)key, hash->table_size);
 	if (!hash->table[hash_val])
-		return (false);
+		return (NULL);
 	if (!hash->table[hash_val]->size)
-		return (false);
-	result = is_key_in_deque(hash->table[hash_val]->node, key);
+		return (NULL);
+	result = find_key_in_deque(hash->table[hash_val]->node, key);
 	return (result);
 }

--- a/libft/srcs/ft_hash/set_key_to_table.c
+++ b/libft/srcs/ft_hash/set_key_to_table.c
@@ -60,8 +60,7 @@ int	set_to_table(t_hash *hash, char *key, void *content)
 		{
 			// clear_hash_elem
 			free(key);
-			// todo: del func
-			free(content);
+			free(content); // todo: del func
 			free(elem);
 			return (HASH_ERROR);
 		}

--- a/libft/srcs/ft_hash/set_key_to_table.c
+++ b/libft/srcs/ft_hash/set_key_to_table.c
@@ -58,10 +58,7 @@ int	set_to_table(t_hash *hash, char *key, void *content)
 		//todo:rehash
 		if (add_elem_to_table(hash, elem) == HASH_ERROR)
 		{
-			// clear_hash_elem
-			free(key);
-			free(content); // todo: del func
-			free(elem);
+			clear_hash_elem(&elem, del);
 			return (HASH_ERROR);
 		}
 		hash->key_count++;

--- a/libft/srcs/ft_hash/set_key_to_table.c
+++ b/libft/srcs/ft_hash/set_key_to_table.c
@@ -42,12 +42,14 @@ static int	add_elem_to_table(t_hash *hash, t_elem *elem)
 // 'key' cannot be null, 'value' can accept null
 int	set_to_table(t_hash *hash, char *key, void *content)
 {
-	t_elem	*elem;
+	t_elem			*elem;
+	t_deque_node	*target_node;
 
 	if (!key)
 		return (HASH_SUCCESS);
-	if (find_key(hash, key))
-		update_content_of_key(hash, key, content);
+	target_node = find_key(hash, key);
+	if (target_node)
+		update_content_of_key(&key, content, target_node);
 	else
 	{
 		elem = create_hash_elem(key, content);

--- a/libft/srcs/ft_hash/set_key_to_table.c
+++ b/libft/srcs/ft_hash/set_key_to_table.c
@@ -56,6 +56,7 @@ int	set_to_table(t_hash *hash, char *key, void *content)
 		//todo:rehash
 		if (add_elem_to_table(hash, elem) == HASH_ERROR)
 		{
+			// clear_hash_elem
 			free(key);
 			// todo: del func
 			free(content);

--- a/libft/srcs/ft_hash/update_value.c
+++ b/libft/srcs/ft_hash/update_value.c
@@ -10,10 +10,9 @@ void	update_content_of_key(char **key, \
 {
 	t_elem	*elem;
 
-	(void)key;
-	// free(*key);
-	// *key = NULL;
+	free(*key);
+	*key = NULL;
 	elem = (t_elem *)target_node->content;
-	// free(elem->content);
+	free(elem->content);
 	elem->content = content;
 }

--- a/libft/srcs/ft_hash/update_value.c
+++ b/libft/srcs/ft_hash/update_value.c
@@ -1,29 +1,14 @@
 #include <stdlib.h>
 #include "ft_deque.h"
-#include "ft_hash.h"
-#include "ft_string.h"
 
 // key exist in hash
 // free(key, pre-content), update new content
-void	update_content_of_key(t_hash *hash, char *key, void *content)
+void	update_content_of_key(char **key, \
+								void *content, \
+								t_deque_node *target_node)
 {
-	uint64_t		hash_val;
-	t_deque_node	*node;
-	t_elem			*elem;
-
-	hash_val = generate_fnv_hash_64((unsigned char *)key, hash->table_size);
-	node = hash->table[hash_val]->node;
-	while (node)
-	{
-		elem = (t_elem *)node->content;
-		if (ft_streq(elem->key, key))
-		{
-			free(key);
-			// todo: del func
-			free(node->content);
-			node->content = content;
-			return ;
-		}
-		node = node->next;
-	}
+	free(*key);
+	*key = NULL;
+	free(target_node->content);
+	target_node->content = content;
 }

--- a/libft/srcs/ft_hash/update_value.c
+++ b/libft/srcs/ft_hash/update_value.c
@@ -1,5 +1,6 @@
 #include <stdlib.h>
 #include "ft_deque.h"
+#include "ft_hash.h"
 
 // key exist in hash
 // free(key, pre-content), update new content
@@ -7,8 +8,12 @@ void	update_content_of_key(char **key, \
 								void *content, \
 								t_deque_node *target_node)
 {
-	free(*key);
-	*key = NULL;
-	free(target_node->content);
-	target_node->content = content;
+	t_elem	*elem;
+
+	(void)key;
+	// free(*key);
+	// *key = NULL;
+	elem = (t_elem *)target_node->content;
+	// free(elem->content);
+	elem->content = content;
 }

--- a/test/unit_test/deque/Makefile
+++ b/test/unit_test/deque/Makefile
@@ -11,7 +11,7 @@ INCLUDES	:=	-I$(LIBFT_DIR)/$(INCLUDES_DIR)/
 DEPS		:=	$(OBJS:.o=.d)
 
 CC			:=	cc
-CFLAGS		:=	-Wall -Wextra -Werror -MMD -MP
+CFLAGS		:=	-Wall -Wextra -Werror -MMD -MP -g -fsanitize=address -fsanitize=undefined
 MKDIR		:=	mkdir -p
 
 NAME		:=	a.out

--- a/test/unit_test/hash/test_hash.c
+++ b/test/unit_test/hash/test_hash.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include "ft_hash.h"
 #include "ft_dprintf.h"
+#include "ft_string.h"
 
 #define COLOR_RED		"\x1b[31m"
 #define COLOR_GREEN		"\x1b[32m"
@@ -45,6 +46,18 @@ int	test_hash_value(char *key, uint64_t mod, uint64_t expected, int no)
 	return (1);
 }
 
+static void	set_to_table_by_allocated_strs(t_hash *hash, const char *s1, const char *s2)
+{
+	char	*s1_dup = NULL;
+	char	*s2_dup = NULL;
+
+	if (s1)
+		s1_dup = ft_strdup(s1);
+	if (s2)
+		s2_dup = ft_strdup(s2);
+	set_to_table(hash, s1_dup, s2_dup);
+}
+
 int	main(void)
 {
 	int	test_no = 0;
@@ -65,26 +78,26 @@ int	main(void)
 		t_hash	*hash = create_hash_table(100);
 		display_hash_table(hash, display_elem);
 
-		set_to_table(hash, "test_key", "test_value");
-		set_to_table(hash, "pien", ";p");
-		set_to_table(hash, "PATH", "/bin:/usr/bin:etc");
+		set_to_table_by_allocated_strs(hash, "test_key", "test_value");
+		set_to_table_by_allocated_strs(hash, "pien", ";p");
+		set_to_table_by_allocated_strs(hash, "PATH", "/bin:/usr/bin:etc");
 		display_table_info(hash);
 
-		set_to_table(hash, "empty string", "");
+		set_to_table_by_allocated_strs(hash, "empty string", "");
 		display_table_info(hash);
 
-		set_to_table(hash, "empty value", NULL);
+		set_to_table_by_allocated_strs(hash, "empty value", NULL);
 		display_table_info(hash);
 
-		set_to_table(hash, "PATHa", "/bin:/usr/bin:etc");
-		set_to_table(hash, "PATH1", "/bin:/usr/bin:etc1");
+		set_to_table_by_allocated_strs(hash, "PATHa", "/bin:/usr/bin:etc");
+		set_to_table_by_allocated_strs(hash, "PATH1", "/bin:/usr/bin:etc1");
 		display_table_info(hash);
 
-		set_to_table(hash, "abc", "abc1");
-		set_to_table(hash, "abc", "abc2");
-		set_to_table(hash, "abc", "abc3");
-		set_to_table(hash, "abc", "abc4");
-		set_to_table(hash, "abc", "abc5");
+		set_to_table_by_allocated_strs(hash, "abc", "abc1");
+		set_to_table_by_allocated_strs(hash, "abc", "abc2");
+		set_to_table_by_allocated_strs(hash, "abc", "abc3");
+		set_to_table_by_allocated_strs(hash, "abc", "abc4");
+		set_to_table_by_allocated_strs(hash, "abc", "abc5");
 		display_table_info(hash);
 
 		clear_hash_table(&hash);

--- a/test/unit_test/hash/test_hash.c
+++ b/test/unit_test/hash/test_hash.c
@@ -65,26 +65,26 @@ int	main(void)
 		t_hash	*hash = create_hash_table(100);
 		display_hash_table(hash, display_elem);
 
-		add_to_table(hash, "test_key", "test_value");
-		add_to_table(hash, "pien", ";p");
-		add_to_table(hash, "PATH", "/bin:/usr/bin:etc");
+		set_to_table(hash, "test_key", "test_value");
+		set_to_table(hash, "pien", ";p");
+		set_to_table(hash, "PATH", "/bin:/usr/bin:etc");
 		display_table_info(hash);
 
-		add_to_table(hash, "empty string", "");
+		set_to_table(hash, "empty string", "");
 		display_table_info(hash);
 
-		add_to_table(hash, "empty value", NULL);
+		set_to_table(hash, "empty value", NULL);
 		display_table_info(hash);
 
-		add_to_table(hash, "PATHa", "/bin:/usr/bin:etc");
-		add_to_table(hash, "PATH1", "/bin:/usr/bin:etc1");
+		set_to_table(hash, "PATHa", "/bin:/usr/bin:etc");
+		set_to_table(hash, "PATH1", "/bin:/usr/bin:etc1");
 		display_table_info(hash);
 
-		add_to_table(hash, "abc", "abc1");
-		add_to_table(hash, "abc", "abc2");
-		add_to_table(hash, "abc", "abc3");
-		add_to_table(hash, "abc", "abc4");
-		add_to_table(hash, "abc", "abc5");
+		set_to_table(hash, "abc", "abc1");
+		set_to_table(hash, "abc", "abc2");
+		set_to_table(hash, "abc", "abc3");
+		set_to_table(hash, "abc", "abc4");
+		set_to_table(hash, "abc", "abc5");
 		display_table_info(hash);
 
 		clear_hash_table(&hash);


### PR DESCRIPTION
先に #133 を merge してからこちらを merge したい。そうするとここの commit が最新 4 件だけになるはず。(-> 手動で pull しないと base-branch は変更されなかった……)
- [x] `unit_test/hash/` : hash に set する文字列を ft_strdup してから渡すように変更
- [x] それにより `libft/ft_hash/` の方で free を復活 (unit_test passed, valgrind でも leak zero)。 一旦 `deque_clear_all` に関数ポインタを渡さず愚直に free。
- [x] ついでに `unit_test/deque` の Makefile flag に sanitize を追加

#129 に関連
