### PR TITLE
hash-update-del

### DIFF
--- a/libft/includes/ft_hash.h
+++ b/libft/includes/ft_hash.h
@@ -34,7 +34,10 @@ t_hash			*create_hash_table(uint64_t size);
 /* add key */
 // add key-value pairs to table and return 0. On error, return (-1)
 // if hash_value conflicts, add with the chain method
-int				set_to_table(t_hash *hash, char *key, void *content);
+int				set_to_table(t_hash *hash, \
+								char *key, \
+								void *content, \
+								void (*del_content)(void *));
 
 /* find key */
 t_deque_node	*find_key(t_hash *hash, const char *key);
@@ -42,16 +45,16 @@ t_deque_node	*find_key(t_hash *hash, const char *key);
 /* get value */
 
 /* update value */
-void			update_content_of_key(t_deque_node *target_node, \
-										char **key, \
-										void *content);
+void			update_content_of_key(char **key, \
+										void *content, \
+										t_deque_node *target_node, \
+										void (*del_content)(void *));
 
 /* del key */
 
 /* clear table */
-void			del(void *content);
-void			clear_hash_elem(t_elem **elem, void (*del)(void *));
-void			clear_hash_table(t_hash **hash);
+void			clear_hash_elem(t_elem **elem, void (*del_content)(void *));
+void			clear_hash_table(t_hash **hash, void (*del_content)(void *));
 
 /* display hash table */
 void			display_hash_table(t_hash *hash, void (*display)(void *));

--- a/libft/srcs/ft_hash/clear_hash_table.c
+++ b/libft/srcs/ft_hash/clear_hash_table.c
@@ -3,23 +3,19 @@
 #include "ft_hash.h"
 #include "ft_mem.h"
 
-void	del(void *content)
-{
-	free(content);
-}
-
-void	clear_hash_elem(t_elem **elem, void (*del)(void *))
+void	clear_hash_elem(t_elem **elem, void (*del_content)(void *))
 {
 	if (!elem || !*elem)
 		return ;
 	ft_free((*elem)->key);
-	del((*elem)->content);
+	del_content((*elem)->content);
 	(*elem)->content = NULL;
 	ft_free(*elem);
 }
 
 // todo: use func pointer?
-static void	tmp_deque_clear_node(t_deque_node **node)
+static void	tmp_deque_clear_node(t_deque_node **node, \
+									void (*del_content)(void *))
 {
 	t_elem	*elem;
 
@@ -27,7 +23,7 @@ static void	tmp_deque_clear_node(t_deque_node **node)
 		return ;
 	elem = (*node)->content;
 	ft_free(elem->key);
-	free(elem->content);
+	del_content(elem->content);
 	elem->content = NULL;
 	ft_free(elem);
 	(*node)->next = NULL;
@@ -36,7 +32,7 @@ static void	tmp_deque_clear_node(t_deque_node **node)
 }
 
 // todo: use func pointer?
-static void	tmp_deque_clear_all(t_deque **deque)
+static void	tmp_deque_clear_all(t_deque **deque, void (*del_content)(void *))
 {
 	t_deque_node	*node;
 	t_deque_node	*tmp;
@@ -51,13 +47,12 @@ static void	tmp_deque_clear_all(t_deque **deque)
 	{
 		tmp = node;
 		node = node->next;
-		tmp_deque_clear_node(&tmp);
+		tmp_deque_clear_node(&tmp, del_content);
 	}
 	ft_free(*deque);
 }
 
-// hash->table not use ft_free
-void	clear_hash_table(t_hash **hash)
+void	clear_hash_table(t_hash **hash, void (*del_content)(void *))
 {
 	size_t	idx;
 
@@ -69,7 +64,7 @@ void	clear_hash_table(t_hash **hash)
 		if ((*hash)->table[idx])
 		{
 			// deque_clear_all(&(*hash)->table[idx]); // TODO: clear_hash_elem
-			tmp_deque_clear_all(&(*hash)->table[idx]);
+			tmp_deque_clear_all(&(*hash)->table[idx], del_content);
 		}
 		idx++;
 	}

--- a/libft/srcs/ft_hash/set_key_to_table.c
+++ b/libft/srcs/ft_hash/set_key_to_table.c
@@ -39,7 +39,9 @@ static int	add_elem_to_table(t_hash *hash, t_elem *elem)
 // if malloc error, return HASH_ERROR
 // hash not freed in func
 // 'key' cannot be null, 'value' can accept null
-int	set_to_table(t_hash *hash, char *key, void *content)
+int	set_to_table(t_hash *hash, char *key, \
+					void *content, \
+					void (*del_content)(void *))
 {
 	t_elem			*elem;
 	t_deque_node	*target_node;
@@ -48,7 +50,7 @@ int	set_to_table(t_hash *hash, char *key, void *content)
 		return (HASH_SUCCESS);
 	target_node = find_key(hash, key);
 	if (target_node)
-		update_content_of_key(target_node, &key, content);
+		update_content_of_key(&key, content, target_node, del_content);
 	else
 	{
 		elem = create_hash_elem(key, content);
@@ -57,7 +59,7 @@ int	set_to_table(t_hash *hash, char *key, void *content)
 		//todo:rehash
 		if (add_elem_to_table(hash, elem) == HASH_ERROR)
 		{
-			clear_hash_elem(&elem, del);
+			clear_hash_elem(&elem, del_content);
 			return (HASH_ERROR);
 		}
 		hash->key_count++;

--- a/libft/srcs/ft_hash/update_value.c
+++ b/libft/srcs/ft_hash/update_value.c
@@ -5,14 +5,15 @@
 
 // key exist in hash
 // free(key, pre-content), update new content
-void	update_content_of_key(t_deque_node *target_node, \
-								char **key, \
-								void *content)
+void	update_content_of_key(char **key, \
+								void *content, \
+								t_deque_node *target_node, \
+								void (*del_content)(void *))
 {
 	t_elem	*elem;
 
 	ft_free(*key);
 	elem = (t_elem *)target_node->content;
-	free(elem->content);
+	del_content(elem->content);
 	elem->content = content;
 }

--- a/test/unit_test/hash/test_hash.c
+++ b/test/unit_test/hash/test_hash.c
@@ -46,6 +46,14 @@ int	test_hash_value(char *key, uint64_t mod, uint64_t expected, int no)
 	return (1);
 }
 
+void	del_elem_content_test(void *content)
+{
+	char	*value;
+
+	value = (char *)content;
+	free(value);
+}
+
 static void	set_to_table_by_allocated_strs(t_hash *hash, const char *s1, const char *s2)
 {
 	char	*s1_dup = NULL;
@@ -55,7 +63,7 @@ static void	set_to_table_by_allocated_strs(t_hash *hash, const char *s1, const c
 		s1_dup = ft_strdup(s1);
 	if (s2)
 		s2_dup = ft_strdup(s2);
-	set_to_table(hash, s1_dup, s2_dup);
+	set_to_table(hash, s1_dup, s2_dup, del_elem_content_test);
 }
 
 int	main(void)
@@ -100,7 +108,7 @@ int	main(void)
 		set_to_table_by_allocated_strs(hash, "abc", "abc5");
 		display_table_info(hash);
 
-		clear_hash_table(&hash);
+		clear_hash_table(&hash, del_elem_content_test);
 
 		printf("\n\n");
 	}
@@ -109,7 +117,7 @@ int	main(void)
 
 		t_hash	*hash = create_hash_table(1);
 		display_table_info(hash);
-		clear_hash_table(&hash);
+		clear_hash_table(&hash, del_elem_content_test);
 		printf("\n\n");
 	}
 


### PR DESCRIPTION
#129 のupdate。

elem->contentをdelするため、関連する関数の引数を変更しましたー！

* elem->content用のdelを使用する関数の引数に関数ポインタを追加 & del_content(content)へ変更
* unit test内でcontentをfreeする関数（`void del_elem_content_test(void *content)`）を作成
* unit testでfreeのチェック済み
* make normでnormチェック済み