### PR TITLE
hash delete key

### DIFF
--- a/libft/includes/ft_hash.h
+++ b/libft/includes/ft_hash.h
@@ -52,6 +52,9 @@ void			update_content_of_key(char **key, \
 										void (*del_content)(void *));
 
 /* del key */
+void			delete_key_from_table(t_hash *hash, \
+										const char *key, \
+										void (*del_content)(void *));
 
 /* clear table */
 void			clear_hash_elem(t_elem **elem, void (*del_content)(void *));

--- a/libft/includes/ft_hash.h
+++ b/libft/includes/ft_hash.h
@@ -55,6 +55,8 @@ void			update_content_of_key(char **key, \
 
 /* clear table */
 void			clear_hash_elem(t_elem **elem, void (*del_content)(void *));
+void			tmp_deque_clear_node(t_deque_node **node, \
+										void (*del_content)(void *));
 void			clear_hash_table(t_hash **hash, void (*del_content)(void *));
 
 /* display hash table */

--- a/libft/srcs/ft_hash/clear_hash_table.c
+++ b/libft/srcs/ft_hash/clear_hash_table.c
@@ -14,8 +14,7 @@ void	clear_hash_elem(t_elem **elem, void (*del_content)(void *))
 }
 
 // todo: use func pointer?
-static void	tmp_deque_clear_node(t_deque_node **node, \
-									void (*del_content)(void *))
+void	tmp_deque_clear_node(t_deque_node **node, void (*del_content)(void *))
 {
 	t_elem	*elem;
 

--- a/libft/srcs/ft_hash/create_hash_table.c
+++ b/libft/srcs/ft_hash/create_hash_table.c
@@ -1,8 +1,6 @@
 #include <stdlib.h>
-#include "ft_deque.h"
 #include "ft_hash.h"
 #include "ft_mem.h"
-#include "ft_string.h"
 
 t_hash	*create_hash_table(uint64_t size)
 {

--- a/libft/srcs/ft_hash/delete_key_from_table.c
+++ b/libft/srcs/ft_hash/delete_key_from_table.c
@@ -4,7 +4,7 @@
 #include "ft_mem.h"
 
 void	delete_key_from_table(t_hash *hash, \
-								const char *key, 
+								const char *key,
 								void (*del_content)(void *))
 {
 	t_deque_node	*target_node;

--- a/libft/srcs/ft_hash/delete_key_from_table.c
+++ b/libft/srcs/ft_hash/delete_key_from_table.c
@@ -19,6 +19,5 @@ void	delete_key_from_table(t_hash *hash, \
 	head = hash->table[hash_val];
 	deque_pop_selected_node(head, target_node);
 	tmp_deque_clear_node(&target_node, del_content);
-	head->size--;
 	hash->key_count--;
 }

--- a/libft/srcs/ft_hash/delete_key_from_table.c
+++ b/libft/srcs/ft_hash/delete_key_from_table.c
@@ -1,2 +1,25 @@
-// del
-//  deque pop
+#include <stdlib.h>
+#include "ft_deque.h"
+#include "ft_hash.h"
+#include "ft_mem.h"
+
+void	delete_key_from_table(t_hash *hash, \
+								const char *key, 
+								void (*del_content)(void *))
+{
+	t_deque_node	*target_node;
+	uint64_t		hash_val;
+	t_deque			*head;
+
+	if (!hash || !key)
+		return ;
+	target_node = find_key(hash, key);
+	if (!target_node)
+		return ;
+	hash_val = gen_fnv_hash((const unsigned char *)key, hash->table_size);
+	head = hash->table[hash_val];
+	deque_pop_selected_node(head, target_node);
+	tmp_deque_clear_node(&target_node, del_content);
+	head->size--;
+	hash->key_count--;
+}

--- a/libft/srcs/ft_hash/delete_key_from_table.c
+++ b/libft/srcs/ft_hash/delete_key_from_table.c
@@ -1,7 +1,6 @@
 #include <stdlib.h>
 #include "ft_deque.h"
 #include "ft_hash.h"
-#include "ft_mem.h"
 
 void	delete_key_from_table(t_hash *hash, \
 								const char *key,

--- a/libft/srcs/ft_hash/display_hash_table.c
+++ b/libft/srcs/ft_hash/display_hash_table.c
@@ -35,7 +35,7 @@ void	display_hash_table(t_hash *hash, void (*display)(void *))
 	idx = 0;
 	while (hash && idx < hash->table_size)
 	{
-		if (hash->table[idx])
+		if (hash->table[idx] && hash->table[idx]->size)
 			print_table_elem(hash->table[idx], display);
 		idx++;
 	}

--- a/libft/srcs/ft_hash/generate_hash.c
+++ b/libft/srcs/ft_hash/generate_hash.c
@@ -1,5 +1,5 @@
+#include <stddef.h>
 #include <stdint.h>
-#include "ft_mem.h"
 
 static uint64_t	modulo_hash_mod(uint64_t hash, uint64_t hash_mod)
 {

--- a/libft/srcs/ft_hash/set_key_to_table.c
+++ b/libft/srcs/ft_hash/set_key_to_table.c
@@ -1,4 +1,3 @@
-#include <stdlib.h>
 #include "ft_deque.h"
 #include "ft_hash.h"
 #include "ft_sys.h"

--- a/libft/srcs/ft_hash/update_value.c
+++ b/libft/srcs/ft_hash/update_value.c
@@ -1,4 +1,3 @@
-#include <stdlib.h>
 #include "ft_deque.h"
 #include "ft_hash.h"
 #include "ft_mem.h"

--- a/test/unit_test/hash/test_hash.c
+++ b/test/unit_test/hash/test_hash.c
@@ -65,12 +65,17 @@ static int	test_get_value(t_hash *hash, char *key, char *expected_val, int no)
 	return (1);
 }
 
-void	del_elem_content_test(void *content)
+static void	del_elem_content_test(void *content)
 {
 	char	*value;
 
 	value = (char *)content;
 	free(value);
+}
+
+static void	test_delete_key_from_table(t_hash *hash, const char *key)
+{
+	delete_key_from_table(hash, key, del_elem_content_test);
 }
 
 static void	set_to_table_by_allocated_strs(t_hash *hash, const char *s1, const char *s2)
@@ -171,7 +176,15 @@ int	main(void)
 		ok += test_get_value(hash,  "42Tokyo", NULL, ++test_no);
 
 		printf("\n   ----- after del key -----\n");
-		// todo:implement del key
+		display_table_info(hash);
+		test_delete_key_from_table(hash, "abc1");
+		display_table_info(hash);
+		test_delete_key_from_table(hash, "12345");
+		display_table_info(hash);
+		test_delete_key_from_table(hash, "not_exist_key");
+		display_table_info(hash);
+		test_delete_key_from_table(hash, "not_exist_key");
+		display_table_info(hash);
 
 		clear_hash_table(&hash, del_elem_content_test);
 		printf("\n\n");


### PR DESCRIPTION
- delete_key_ftom_table を実装。
一旦 del() 関数ポインタを使った tmp_deque_clear_node を使ってます。
unit_test ok, no leaks, norm ok

- ついでに不要 include を削除。


issus #122, PR #129