### PR TITLE
(hash) update del func

### DIFF
--- a/libft/includes/ft_deque.h
+++ b/libft/includes/ft_deque.h
@@ -21,8 +21,10 @@ void			deque_add_first_node(t_deque *deque, t_deque_node *new_node);
 void			deque_add_front(t_deque *deque, t_deque_node *new_node);
 
 /* clear */
-void			deque_clear_all(t_deque **deque);
-void			deque_clear_node(t_deque_node **node);
+//void			deque_clear_all(t_deque **deque);
+//void			deque_clear_node(t_deque_node **node);
+void			deque_clear_all(t_deque **deque, void (*del)(void *));
+void			deque_clear_node(t_deque_node **node, void (*del)(void *));
 
 /* is_empty */
 bool			deque_is_empty(t_deque *deque);

--- a/libft/includes/ft_hash.h
+++ b/libft/includes/ft_hash.h
@@ -22,6 +22,7 @@ typedef struct s_hash_element
 {
 	char	*key;
 	void	*content;
+	void	(*del_content)(void *);
 }	t_elem;
 
 /* hash value */
@@ -48,19 +49,16 @@ void			*get_value_from_table(t_hash *hash, const char *key);
 /* update value */
 void			update_content_of_key(char **key, \
 										void *content, \
-										t_deque_node *target_node, \
-										void (*del_content)(void *));
+										t_deque_node *target_node);
 
 /* del key */
 void			delete_key_from_table(t_hash *hash, \
-										const char *key, \
-										void (*del_content)(void *));
+										const char *key);
 
 /* clear table */
-void			clear_hash_elem(t_elem **elem, void (*del_content)(void *));
-void			tmp_deque_clear_node(t_deque_node **node, \
-										void (*del_content)(void *));
-void			clear_hash_table(t_hash **hash, void (*del_content)(void *));
+void			clear_hash_elem(t_elem **elem);
+void			tmp_deque_clear_node(t_deque_node **node);
+void			clear_hash_table(t_hash **hash);
 
 /* display hash table */
 void			display_hash_table(t_hash *hash, void (*display)(void *));

--- a/libft/includes/ft_hash.h
+++ b/libft/includes/ft_hash.h
@@ -59,6 +59,7 @@ void			delete_key_from_table(t_hash *hash, \
 void			clear_hash_elem(t_elem **elem);
 void			tmp_deque_clear_node(t_deque_node **node);
 void			clear_hash_table(t_hash **hash);
+void			del_hash_elem(void *deque_content);
 
 /* display hash table */
 void			display_hash_table(t_hash *hash, void (*display)(void *));

--- a/libft/srcs/ft_deque/dq_clear_all.c
+++ b/libft/srcs/ft_deque/dq_clear_all.c
@@ -1,7 +1,29 @@
 #include <stdlib.h>
 #include "ft_deque.h"
 
-void	deque_clear_all(t_deque **deque)
+//void	deque_clear_all(t_deque **deque)
+//{
+//	t_deque_node	*node;
+//	t_deque_node	*tmp;
+//
+//	if (deque_is_empty(*deque))
+//	{
+//		free(*deque);
+//		*deque = NULL;
+//		return ;
+//	}
+//	node = (*deque)->node;
+//	while (node)
+//	{
+//		tmp = node;
+//		node = node->next;
+//		deque_clear_node(&tmp);
+//	}
+//	free(*deque);
+//	*deque = NULL;
+//}
+
+void	deque_clear_all(t_deque **deque, void (*del)(void *))
 {
 	t_deque_node	*node;
 	t_deque_node	*tmp;
@@ -17,7 +39,7 @@ void	deque_clear_all(t_deque **deque)
 	{
 		tmp = node;
 		node = node->next;
-		deque_clear_node(&tmp);
+		deque_clear_node(&tmp, del);
 	}
 	free(*deque);
 	*deque = NULL;

--- a/libft/srcs/ft_deque/dq_clear_node.c
+++ b/libft/srcs/ft_deque/dq_clear_node.c
@@ -1,11 +1,23 @@
 #include <stdlib.h>
 #include "ft_deque.h"
 
-void	deque_clear_node(t_deque_node **node)
+//void	deque_clear_node(t_deque_node **node)
+//{
+//	if (!*node)
+//		return ;
+//	free((*node)->content);
+//	(*node)->content = NULL;
+//	(*node)->next = NULL;
+//	(*node)->prev = NULL;
+//	free(*node);
+//	*node = NULL;
+//}
+
+void	deque_clear_node(t_deque_node **node, void (*del)(void *))
 {
 	if (!*node)
 		return ;
-	free((*node)->content);
+	del((*node)->content);
 	(*node)->content = NULL;
 	(*node)->next = NULL;
 	(*node)->prev = NULL;

--- a/libft/srcs/ft_hash/clear_hash_table.c
+++ b/libft/srcs/ft_hash/clear_hash_table.c
@@ -3,18 +3,18 @@
 #include "ft_hash.h"
 #include "ft_mem.h"
 
-void	clear_hash_elem(t_elem **elem, void (*del_content)(void *))
+void	clear_hash_elem(t_elem **elem)
 {
 	if (!elem || !*elem)
 		return ;
 	ft_free((*elem)->key);
-	del_content((*elem)->content);
+	(*elem)->del_content((*elem)->content);
 	(*elem)->content = NULL;
 	ft_free(*elem);
 }
 
 // todo: use func pointer?
-void	tmp_deque_clear_node(t_deque_node **node, void (*del_content)(void *))
+void	tmp_deque_clear_node(t_deque_node **node)
 {
 	t_elem	*elem;
 
@@ -22,7 +22,7 @@ void	tmp_deque_clear_node(t_deque_node **node, void (*del_content)(void *))
 		return ;
 	elem = (*node)->content;
 	ft_free(elem->key);
-	del_content(elem->content);
+	(*elem).del_content((*elem).content);
 	elem->content = NULL;
 	ft_free(elem);
 	(*node)->next = NULL;
@@ -31,7 +31,7 @@ void	tmp_deque_clear_node(t_deque_node **node, void (*del_content)(void *))
 }
 
 // todo: use func pointer?
-static void	tmp_deque_clear_all(t_deque **deque, void (*del_content)(void *))
+static void	tmp_deque_clear_all(t_deque **deque)
 {
 	t_deque_node	*node;
 	t_deque_node	*tmp;
@@ -46,12 +46,12 @@ static void	tmp_deque_clear_all(t_deque **deque, void (*del_content)(void *))
 	{
 		tmp = node;
 		node = node->next;
-		tmp_deque_clear_node(&tmp, del_content);
+		tmp_deque_clear_node(&tmp);
 	}
 	ft_free(*deque);
 }
 
-void	clear_hash_table(t_hash **hash, void (*del_content)(void *))
+void	clear_hash_table(t_hash **hash)
 {
 	size_t	idx;
 
@@ -63,7 +63,7 @@ void	clear_hash_table(t_hash **hash, void (*del_content)(void *))
 		if ((*hash)->table[idx])
 		{
 			// deque_clear_all(&(*hash)->table[idx]); // TODO: clear_hash_elem
-			tmp_deque_clear_all(&(*hash)->table[idx], del_content);
+			tmp_deque_clear_all(&(*hash)->table[idx]);
 		}
 		idx++;
 	}

--- a/libft/srcs/ft_hash/clear_hash_table.c
+++ b/libft/srcs/ft_hash/clear_hash_table.c
@@ -3,64 +3,16 @@
 #include "ft_hash.h"
 #include "ft_mem.h"
 
-static void	del_hash_elem(void *content)
+void	del_hash_elem(void *deque_content)
 {
 	t_elem	*elem;
 
-	if (!content)
+	if (!deque_content)
 		return ;
-	elem = (t_elem *)content;
-	ft_free(elem->key);
+	elem = (t_elem *)deque_content;
+	free(elem->key);
 	elem->del_content(elem->content);
-	ft_free(elem);
-}
-
-void	clear_hash_elem(t_elem **elem)
-{
-	if (!elem || !*elem)
-		return ;
-	ft_free((*elem)->key);
-	(*elem)->del_content((*elem)->content);
-	(*elem)->content = NULL;
-	ft_free(*elem);
-}
-
-// todo: use func pointer?
-void	tmp_deque_clear_node(t_deque_node **node)
-{
-	t_elem	*elem;
-
-	if (!*node)
-		return ;
-	elem = (*node)->content;
-	ft_free(elem->key);
-	(*elem).del_content((*elem).content);
-	elem->content = NULL;
-	ft_free(elem);
-	(*node)->next = NULL;
-	(*node)->prev = NULL;
-	ft_free(*node);
-}
-
-// todo: use func pointer?
-static void	tmp_deque_clear_all(t_deque **deque)
-{
-	t_deque_node	*node;
-	t_deque_node	*tmp;
-
-	if (deque_is_empty(*deque))
-	{
-		ft_free(*deque);
-		return ;
-	}
-	node = (*deque)->node;
-	while (node)
-	{
-		tmp = node;
-		node = node->next;
-		tmp_deque_clear_node(&tmp);
-	}
-	ft_free(*deque);
+	free(elem);
 }
 
 void	clear_hash_table(t_hash **hash)
@@ -73,10 +25,7 @@ void	clear_hash_table(t_hash **hash)
 	while (idx < (*hash)->table_size)
 	{
 		if ((*hash)->table[idx])
-		{
-			// deque_clear_all(&(*hash)->table[idx]); // TODO: clear_hash_elem
-			tmp_deque_clear_all(&(*hash)->table[idx]);
-		}
+			deque_clear_all(&(*hash)->table[idx], del_hash_elem);
 		idx++;
 	}
 	free((*hash)->table);

--- a/libft/srcs/ft_hash/clear_hash_table.c
+++ b/libft/srcs/ft_hash/clear_hash_table.c
@@ -3,6 +3,18 @@
 #include "ft_hash.h"
 #include "ft_mem.h"
 
+static void	del_hash_elem(void *content)
+{
+	t_elem	*elem;
+
+	if (!content)
+		return ;
+	elem = (t_elem *)content;
+	ft_free(elem->key);
+	elem->del_content(elem->content);
+	ft_free(elem);
+}
+
 void	clear_hash_elem(t_elem **elem)
 {
 	if (!elem || !*elem)

--- a/libft/srcs/ft_hash/delete_key_from_table.c
+++ b/libft/srcs/ft_hash/delete_key_from_table.c
@@ -16,6 +16,6 @@ void	delete_key_from_table(t_hash *hash, const char *key)
 	hash_val = gen_fnv_hash((const unsigned char *)key, hash->table_size);
 	head = hash->table[hash_val];
 	deque_pop_selected_node(head, target_node);
-	tmp_deque_clear_node(&target_node);
+	deque_clear_node(&target_node, del_hash_elem);
 	hash->key_count--;
 }

--- a/libft/srcs/ft_hash/delete_key_from_table.c
+++ b/libft/srcs/ft_hash/delete_key_from_table.c
@@ -2,9 +2,7 @@
 #include "ft_deque.h"
 #include "ft_hash.h"
 
-void	delete_key_from_table(t_hash *hash, \
-								const char *key,
-								void (*del_content)(void *))
+void	delete_key_from_table(t_hash *hash, const char *key)
 {
 	t_deque_node	*target_node;
 	uint64_t		hash_val;
@@ -18,6 +16,6 @@ void	delete_key_from_table(t_hash *hash, \
 	hash_val = gen_fnv_hash((const unsigned char *)key, hash->table_size);
 	head = hash->table[hash_val];
 	deque_pop_selected_node(head, target_node);
-	tmp_deque_clear_node(&target_node, del_content);
+	tmp_deque_clear_node(&target_node);
 	hash->key_count--;
 }

--- a/libft/srcs/ft_hash/set_key_to_table.c
+++ b/libft/srcs/ft_hash/set_key_to_table.c
@@ -61,7 +61,8 @@ int	set_to_table(t_hash *hash, char *key, \
 		//todo:rehash
 		if (add_elem_to_table(hash, elem) == HASH_ERROR)
 		{
-			clear_hash_elem(&elem);
+			del_hash_elem(elem);
+//			clear_hash_elem(&elem);
 			return (HASH_ERROR);
 		}
 		hash->key_count++;

--- a/libft/srcs/ft_hash/set_key_to_table.c
+++ b/libft/srcs/ft_hash/set_key_to_table.c
@@ -3,7 +3,9 @@
 #include "ft_sys.h"
 
 // if malloc error, return NULL
-static t_elem	*create_hash_elem(char *key, void *content)
+static t_elem	*create_hash_elem(char *key, \
+									void *content, \
+									void (*del_content)(void *))
 {
 	t_elem	*elem;
 
@@ -12,6 +14,7 @@ static t_elem	*create_hash_elem(char *key, void *content)
 		return (NULL);
 	elem->key = key;
 	elem->content = content;
+	elem->del_content = del_content;
 	return (elem);
 }
 
@@ -49,16 +52,16 @@ int	set_to_table(t_hash *hash, char *key, \
 		return (HASH_SUCCESS);
 	target_node = find_key(hash, key);
 	if (target_node)
-		update_content_of_key(&key, content, target_node, del_content);
+		update_content_of_key(&key, content, target_node);
 	else
 	{
-		elem = create_hash_elem(key, content);
+		elem = create_hash_elem(key, content, del_content);
 		if (!elem)
 			return (HASH_ERROR);
 		//todo:rehash
 		if (add_elem_to_table(hash, elem) == HASH_ERROR)
 		{
-			clear_hash_elem(&elem, del_content);
+			clear_hash_elem(&elem);
 			return (HASH_ERROR);
 		}
 		hash->key_count++;

--- a/libft/srcs/ft_hash/update_value.c
+++ b/libft/srcs/ft_hash/update_value.c
@@ -6,13 +6,12 @@
 // free(key, pre-content), update new content
 void	update_content_of_key(char **key, \
 								void *content, \
-								t_deque_node *target_node, \
-								void (*del_content)(void *))
+								t_deque_node *target_node)
 {
 	t_elem	*elem;
 
 	ft_free(*key);
 	elem = (t_elem *)target_node->content;
-	del_content(elem->content);
+	elem->del_content(elem->content);
 	elem->content = content;
 }

--- a/srcs/exec/child_process.c
+++ b/srcs/exec/child_process.c
@@ -1,6 +1,5 @@
 #include <stdlib.h>
 #include "minishell.h"
-#include "ms_builtin.h"
 #include "ms_exec.h"
 #include "ft_deque.h"
 #include "ft_dprintf.h"
@@ -11,7 +10,7 @@ static int	execute_builtin_command(t_command *cmd, t_params *params)
 	int			exec_status;
 
 	exec_status = call_builtin_command(command, params);
-	deque_clear_all(&cmd->head_command);
+	deque_clear_all(&cmd->head_command, free);
 	return (exec_status);
 }
 
@@ -25,7 +24,7 @@ static int	execute_external_command(t_command *cmd, char **environ)
 	{
 		ft_dprintf(STDERR_FILENO, "%s: %s: %s\n", \
 					SHELL_NAME, command[0], ERROR_MSG_CMD_NOT_FOUND);
-		deque_clear_all(&cmd->head_command);
+		deque_clear_all(&cmd->head_command, free);
 	}
 	return (EXIT_CODE_NO_SUCH_FILE);
 }

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -24,7 +24,7 @@ int	main(void)
 			return (EXIT_FAILURE);
 		// parse()
 		params.status = execute_command(command, &params);
-		deque_clear_all(&command);
+		deque_clear_all(&command, free);
 		if (params.status == PROCESS_ERROR)
 			return (EXIT_FAILURE);
 	}

--- a/test/unit_test/hash/test_hash.c
+++ b/test/unit_test/hash/test_hash.c
@@ -75,7 +75,7 @@ static void	del_elem_content_test(void *content)
 
 static void	test_delete_key_from_table(t_hash *hash, const char *key)
 {
-	delete_key_from_table(hash, key, del_elem_content_test);
+	delete_key_from_table(hash, key);
 }
 
 static void	set_to_table_by_allocated_strs(t_hash *hash, const char *s1, const char *s2)
@@ -132,7 +132,7 @@ int	main(void)
 		set_to_table_by_allocated_strs(hash, "abc", "abc5");
 		display_table_info(hash);
 
-		clear_hash_table(&hash, del_elem_content_test);
+		clear_hash_table(&hash);
 
 		printf("\n\n");
 	}
@@ -141,7 +141,7 @@ int	main(void)
 
 		t_hash	*hash = create_hash_table(1);
 		display_table_info(hash);
-		clear_hash_table(&hash, del_elem_content_test);
+		clear_hash_table(&hash);
 		printf("\n\n");
 	}
 	{
@@ -186,7 +186,7 @@ int	main(void)
 		test_delete_key_from_table(hash, "not_exist_key");
 		display_table_info(hash);
 
-		clear_hash_table(&hash, del_elem_content_test);
+		clear_hash_table(&hash);
 		printf("\n\n");
 	}
 


### PR DESCRIPTION
* 実験用のブランチ
* hashのelem-> void *contentを削除する関数del_contentをelem内部に保持するよう変更
   https://github.com/habvi/42_minishell/blob/6e7dd970bad6bb2f783db6c1098383f93d8cb3c3/libft/includes/ft_hash.h#L21-L26
* deque_clear_all(), deque_clear_node() の content削除を関数ポインタで渡すよう変更
* とりあえずできたが、もう少しスマートな方法を模索する