### PR TITLE
144 hash del func last

### DIFF
--- a/libft/Makefile
+++ b/libft/Makefile
@@ -31,16 +31,16 @@ DEQUE_SRC	:=	$(DEQUE_DIR)/dq_add_back.c \
 # ft_hash
 #--------------------------------------------
 HASH_DIR	:=	ft_hash
-HASH_SRC	:=	$(HASH_DIR)/clear_hash_table.c \
-				$(HASH_DIR)/create_hash_table.c \
-				$(HASH_DIR)/delete_key_from_table.c \
-				$(HASH_DIR)/display_hash_table.c \
-				$(HASH_DIR)/find_key_from_table.c \
-				$(HASH_DIR)/generate_hash.c \
-				$(HASH_DIR)/get_value_from_table.c \
-				$(HASH_DIR)/rehash_table.c \
-				$(HASH_DIR)/set_key_to_table.c \
-				$(HASH_DIR)/update_value.c
+HASH_SRC	:=	$(HASH_DIR)/hs_clear_table.c \
+				$(HASH_DIR)/hs_create_table.c \
+				$(HASH_DIR)/hs_delete_key.c \
+				$(HASH_DIR)/hs_display.c \
+				$(HASH_DIR)/hs_find_key.c \
+				$(HASH_DIR)/hs_gen_fnv.c \
+				$(HASH_DIR)/hs_get_value.c \
+				$(HASH_DIR)/hs_rehash_table.c \
+				$(HASH_DIR)/hs_set_key.c \
+				$(HASH_DIR)/hs_update_value.c
 
 #--------------------------------------------
 # ft_lib

--- a/libft/includes/ft_deque.h
+++ b/libft/includes/ft_deque.h
@@ -21,8 +21,10 @@ void			deque_add_first_node(t_deque *deque, t_deque_node *new_node);
 void			deque_add_front(t_deque *deque, t_deque_node *new_node);
 
 /* clear */
-void			deque_clear_all(t_deque **deque);
-void			deque_clear_node(t_deque_node **node);
+//void			deque_clear_all(t_deque **deque);
+//void			deque_clear_node(t_deque_node **node);
+void			deque_clear_all(t_deque **deque, void (*del)(void *));
+void			deque_clear_node(t_deque_node **node, void (*del)(void *));
 
 /* is_empty */
 bool			deque_is_empty(t_deque *deque);

--- a/libft/includes/ft_hash.h
+++ b/libft/includes/ft_hash.h
@@ -55,7 +55,7 @@ void			delete_key_from_table(t_hash *hash, const char *key);
 
 /* clear table */
 void			clear_hash_elem(t_elem **elem, void (*del_value)(void *));
-void			tmp_deque_clear_node(t_deque_node **node, \
+void			hash_deque_clear_node(t_deque_node **node, \
 										void (*del_value)(void *));
 void			clear_hash_table(t_hash **hash);
 

--- a/libft/includes/ft_hash.h
+++ b/libft/includes/ft_hash.h
@@ -27,43 +27,43 @@ typedef struct s_hash_element
 }	t_elem;
 
 /* hash value */
-uint64_t		gen_fnv_hash(const unsigned char *key, uint64_t hash_mod);
+uint64_t		hs_gen_fnv(const unsigned char *key, uint64_t hash_mod);
 
 /* generate hash table */
 // return a pointer to the hash table. On error, return NULL
-t_hash			*create_hash_table(uint64_t size, void (*del_value)(void *));
+t_hash			*hs_create_table(uint64_t size, void (*del_value)(void *));
 
 /* add key */
 // add key-value pairs to table and return 0. On error, return (-1)
 // if hash_value conflicts, add with the chain method
-int				set_to_table(t_hash *hash, char *key, void *content);
+int				hs_set_key(t_hash *hash, char *key, void *content);
 
 /* find key */
-t_deque_node	*find_key(t_hash *hash, const char *key);
+t_deque_node	*hs_find_key(t_hash *hash, const char *key);
 
 /* get value */
-void			*get_value_from_table(t_hash *hash, const char *key);
+void			*hs_get_value(t_hash *hash, const char *key);
 
 /* update value */
-void			update_content_of_key(char **key, \
+void			hs_update_value(char **key, \
 										void *content, \
 										t_deque_node *target_node, \
 										void (*del_value)(void *));
 
 /* del key */
-void			delete_key_from_table(t_hash *hash, const char *key);
+void			hs_delete_key(t_hash *hash, const char *key);
 
 /* clear table */
-void			clear_hash_elem(t_elem **elem, void (*del_value)(void *));
-void			hash_deque_clear_node(t_deque_node **node, \
+void			hs_clear_elem(t_elem **elem, void (*del_value)(void *));
+void			hs_clear_deque_node(t_deque_node **node, \
 										void (*del_value)(void *));
-void			clear_hash_table(t_hash **hash);
+void			hs_clear_table(t_hash **hash);
 
 /* display hash table */
-void			display_hash_table(t_hash *hash, void (*display)(void *));
+void			hs_display(t_hash *hash, void (*display)(void *));
 
 /* rehash */
 bool			is_need_rehash(t_hash *hash);
-int				rehash_table(t_hash *hash);
+int				hs_rehash_table(t_hash *hash);
 
 #endif //FT_HASH_H

--- a/libft/includes/ft_hash.h
+++ b/libft/includes/ft_hash.h
@@ -23,7 +23,7 @@ typedef struct s_hash_table
 typedef struct s_hash_element
 {
 	char	*key;
-	void	*content;
+	void	*value;
 }	t_elem;
 
 /* hash value */
@@ -36,7 +36,7 @@ t_hash			*hs_create_table(uint64_t size, void (*del_value)(void *));
 /* add key */
 // add key-value pairs to table and return 0. On error, return (-1)
 // if hash_value conflicts, add with the chain method
-int				hs_set_key(t_hash *hash, char *key, void *content);
+int				hs_set_key(t_hash *hash, char *key, void *value);
 
 /* find key */
 t_deque_node	*hs_find_key(t_hash *hash, const char *key);
@@ -46,9 +46,9 @@ void			*hs_get_value(t_hash *hash, const char *key);
 
 /* update value */
 void			hs_update_value(char **key, \
-										void *content, \
-										t_deque_node *target_node, \
-										void (*del_value)(void *));
+								void *value, \
+								t_deque_node *target_node, \
+								void (*del_value)(void *));
 
 /* del key */
 void			hs_delete_key(t_hash *hash, const char *key);

--- a/libft/includes/ft_hash.h
+++ b/libft/includes/ft_hash.h
@@ -36,10 +36,7 @@ t_hash			*create_hash_table(uint64_t size, void (*del_value)(void *));
 /* add key */
 // add key-value pairs to table and return 0. On error, return (-1)
 // if hash_value conflicts, add with the chain method
-int				set_to_table(t_hash *hash, \
-								char *key, \
-								void *content, \
-								void (*del_content)(void *));
+int				set_to_table(t_hash *hash, char *key, void *content);
 
 /* find key */
 t_deque_node	*find_key(t_hash *hash, const char *key);
@@ -51,18 +48,16 @@ void			*get_value_from_table(t_hash *hash, const char *key);
 void			update_content_of_key(char **key, \
 										void *content, \
 										t_deque_node *target_node, \
-										void (*del_content)(void *));
+										void (*del_value)(void *));
 
 /* del key */
-void			delete_key_from_table(t_hash *hash, \
-										const char *key, \
-										void (*del_content)(void *));
+void			delete_key_from_table(t_hash *hash, const char *key);
 
 /* clear table */
-void			clear_hash_elem(t_elem **elem, void (*del_content)(void *));
+void			clear_hash_elem(t_elem **elem, void (*del_value)(void *));
 void			tmp_deque_clear_node(t_deque_node **node, \
-										void (*del_content)(void *));
-void			clear_hash_table(t_hash **hash, void (*del_content)(void *));
+										void (*del_value)(void *));
+void			clear_hash_table(t_hash **hash);
 
 /* display hash table */
 void			display_hash_table(t_hash *hash, void (*display)(void *));

--- a/libft/includes/ft_hash.h
+++ b/libft/includes/ft_hash.h
@@ -17,6 +17,7 @@ typedef struct s_hash_table
 	size_t	table_size;
 	size_t	key_count;
 	t_deque	**table;
+	void	(*del_value)(void *);
 }	t_hash;
 
 typedef struct s_hash_element
@@ -30,7 +31,7 @@ uint64_t		gen_fnv_hash(const unsigned char *key, uint64_t hash_mod);
 
 /* generate hash table */
 // return a pointer to the hash table. On error, return NULL
-t_hash			*create_hash_table(uint64_t size);
+t_hash			*create_hash_table(uint64_t size, void (*del_value)(void *));
 
 /* add key */
 // add key-value pairs to table and return 0. On error, return (-1)

--- a/libft/srcs/ft_deque/dq_clear_all.c
+++ b/libft/srcs/ft_deque/dq_clear_all.c
@@ -1,7 +1,29 @@
 #include <stdlib.h>
 #include "ft_deque.h"
 
-void	deque_clear_all(t_deque **deque)
+//void	deque_clear_all(t_deque **deque)
+//{
+//	t_deque_node	*node;
+//	t_deque_node	*tmp;
+//
+//	if (deque_is_empty(*deque))
+//	{
+//		free(*deque);
+//		*deque = NULL;
+//		return ;
+//	}
+//	node = (*deque)->node;
+//	while (node)
+//	{
+//		tmp = node;
+//		node = node->next;
+//		deque_clear_node(&tmp);
+//	}
+//	free(*deque);
+//	*deque = NULL;
+//}
+
+void	deque_clear_all(t_deque **deque, void (*del)(void *))
 {
 	t_deque_node	*node;
 	t_deque_node	*tmp;
@@ -17,7 +39,7 @@ void	deque_clear_all(t_deque **deque)
 	{
 		tmp = node;
 		node = node->next;
-		deque_clear_node(&tmp);
+		deque_clear_node(&tmp, del);
 	}
 	free(*deque);
 	*deque = NULL;

--- a/libft/srcs/ft_deque/dq_clear_node.c
+++ b/libft/srcs/ft_deque/dq_clear_node.c
@@ -1,11 +1,23 @@
 #include <stdlib.h>
 #include "ft_deque.h"
 
-void	deque_clear_node(t_deque_node **node)
+//void	deque_clear_node(t_deque_node **node)
+//{
+//	if (!*node)
+//		return ;
+//	free((*node)->content);
+//	(*node)->content = NULL;
+//	(*node)->next = NULL;
+//	(*node)->prev = NULL;
+//	free(*node);
+//	*node = NULL;
+//}
+
+void	deque_clear_node(t_deque_node **node, void (*del)(void *))
 {
 	if (!*node)
 		return ;
-	free((*node)->content);
+	del((*node)->content);
 	(*node)->content = NULL;
 	(*node)->next = NULL;
 	(*node)->prev = NULL;

--- a/libft/srcs/ft_hash/clear_hash_table.c
+++ b/libft/srcs/ft_hash/clear_hash_table.c
@@ -13,25 +13,20 @@ void	clear_hash_elem(t_elem **elem, void (*del_value)(void *))
 	ft_free(*elem);
 }
 
-// todo: use func pointer?
-void	tmp_deque_clear_node(t_deque_node **node, void (*del_value)(void *))
+void	hash_deque_clear_node(t_deque_node **node, void (*del_value)(void *))
 {
 	t_elem	*elem;
 
 	if (!*node)
 		return ;
 	elem = (*node)->content;
-	ft_free(elem->key);
-	del_value(elem->content);
-	elem->content = NULL;
-	ft_free(elem);
+	clear_hash_elem(&elem, del_value);
 	(*node)->next = NULL;
 	(*node)->prev = NULL;
 	ft_free(*node);
 }
 
-// todo: use func pointer?
-static void	tmp_deque_clear_all(t_deque **deque, void (*del_value)(void *))
+static void	hash_deque_clear_all(t_deque **deque, void (*del_value)(void *))
 {
 	t_deque_node	*node;
 	t_deque_node	*tmp;
@@ -39,6 +34,7 @@ static void	tmp_deque_clear_all(t_deque **deque, void (*del_value)(void *))
 	if (deque_is_empty(*deque))
 	{
 		ft_free(*deque);
+		*deque = NULL;
 		return ;
 	}
 	node = (*deque)->node;
@@ -46,9 +42,10 @@ static void	tmp_deque_clear_all(t_deque **deque, void (*del_value)(void *))
 	{
 		tmp = node;
 		node = node->next;
-		tmp_deque_clear_node(&tmp, del_value);
+		hash_deque_clear_node(&tmp, del_value);
 	}
 	ft_free(*deque);
+	*deque = NULL;
 }
 
 void	clear_hash_table(t_hash **hash)
@@ -61,10 +58,7 @@ void	clear_hash_table(t_hash **hash)
 	while (idx < (*hash)->table_size)
 	{
 		if ((*hash)->table[idx])
-		{
-			// deque_clear_all(&(*hash)->table[idx]); // TODO: clear_hash_elem
-			tmp_deque_clear_all(&(*hash)->table[idx], (*hash)->del_value);
-		}
+			hash_deque_clear_all(&(*hash)->table[idx], (*hash)->del_value);
 		idx++;
 	}
 	free((*hash)->table);

--- a/libft/srcs/ft_hash/clear_hash_table.c
+++ b/libft/srcs/ft_hash/clear_hash_table.c
@@ -3,18 +3,18 @@
 #include "ft_hash.h"
 #include "ft_mem.h"
 
-void	clear_hash_elem(t_elem **elem, void (*del_content)(void *))
+void	clear_hash_elem(t_elem **elem, void (*del_value)(void *))
 {
 	if (!elem || !*elem)
 		return ;
 	ft_free((*elem)->key);
-	del_content((*elem)->content);
+	del_value((*elem)->content);
 	(*elem)->content = NULL;
 	ft_free(*elem);
 }
 
 // todo: use func pointer?
-void	tmp_deque_clear_node(t_deque_node **node, void (*del_content)(void *))
+void	tmp_deque_clear_node(t_deque_node **node, void (*del_value)(void *))
 {
 	t_elem	*elem;
 
@@ -22,7 +22,7 @@ void	tmp_deque_clear_node(t_deque_node **node, void (*del_content)(void *))
 		return ;
 	elem = (*node)->content;
 	ft_free(elem->key);
-	del_content(elem->content);
+	del_value(elem->content);
 	elem->content = NULL;
 	ft_free(elem);
 	(*node)->next = NULL;
@@ -31,7 +31,7 @@ void	tmp_deque_clear_node(t_deque_node **node, void (*del_content)(void *))
 }
 
 // todo: use func pointer?
-static void	tmp_deque_clear_all(t_deque **deque, void (*del_content)(void *))
+static void	tmp_deque_clear_all(t_deque **deque, void (*del_value)(void *))
 {
 	t_deque_node	*node;
 	t_deque_node	*tmp;
@@ -46,12 +46,12 @@ static void	tmp_deque_clear_all(t_deque **deque, void (*del_content)(void *))
 	{
 		tmp = node;
 		node = node->next;
-		tmp_deque_clear_node(&tmp, del_content);
+		tmp_deque_clear_node(&tmp, del_value);
 	}
 	ft_free(*deque);
 }
 
-void	clear_hash_table(t_hash **hash, void (*del_content)(void *))
+void	clear_hash_table(t_hash **hash)
 {
 	size_t	idx;
 
@@ -63,7 +63,7 @@ void	clear_hash_table(t_hash **hash, void (*del_content)(void *))
 		if ((*hash)->table[idx])
 		{
 			// deque_clear_all(&(*hash)->table[idx]); // TODO: clear_hash_elem
-			tmp_deque_clear_all(&(*hash)->table[idx], del_content);
+			tmp_deque_clear_all(&(*hash)->table[idx], (*hash)->del_value);
 		}
 		idx++;
 	}

--- a/libft/srcs/ft_hash/create_hash_table.c
+++ b/libft/srcs/ft_hash/create_hash_table.c
@@ -6,6 +6,10 @@ t_hash	*create_hash_table(uint64_t size, void (*del_value)(void *))
 {
 	t_hash	*hash;
 
+	if (!del_value)
+		return (NULL);
+	if (!size)
+		size++;
 	hash = (t_hash *)malloc(sizeof(t_hash));
 	if (!hash)
 		return (NULL);

--- a/libft/srcs/ft_hash/create_hash_table.c
+++ b/libft/srcs/ft_hash/create_hash_table.c
@@ -2,7 +2,7 @@
 #include "ft_hash.h"
 #include "ft_mem.h"
 
-t_hash	*create_hash_table(uint64_t size)
+t_hash	*create_hash_table(uint64_t size, void (*del_value)(void *))
 {
 	t_hash	*hash;
 
@@ -17,5 +17,6 @@ t_hash	*create_hash_table(uint64_t size)
 		ft_free(hash);
 		return (NULL);
 	}
+	hash->del_value = del_value;
 	return (hash);
 }

--- a/libft/srcs/ft_hash/delete_key_from_table.c
+++ b/libft/srcs/ft_hash/delete_key_from_table.c
@@ -2,9 +2,7 @@
 #include "ft_deque.h"
 #include "ft_hash.h"
 
-void	delete_key_from_table(t_hash *hash, \
-								const char *key,
-								void (*del_content)(void *))
+void	delete_key_from_table(t_hash *hash, const char *key)
 {
 	t_deque_node	*target_node;
 	uint64_t		hash_val;
@@ -18,6 +16,6 @@ void	delete_key_from_table(t_hash *hash, \
 	hash_val = gen_fnv_hash((const unsigned char *)key, hash->table_size);
 	head = hash->table[hash_val];
 	deque_pop_selected_node(head, target_node);
-	tmp_deque_clear_node(&target_node, del_content);
+	tmp_deque_clear_node(&target_node, hash->del_value);
 	hash->key_count--;
 }

--- a/libft/srcs/ft_hash/delete_key_from_table.c
+++ b/libft/srcs/ft_hash/delete_key_from_table.c
@@ -16,6 +16,6 @@ void	delete_key_from_table(t_hash *hash, const char *key)
 	hash_val = gen_fnv_hash((const unsigned char *)key, hash->table_size);
 	head = hash->table[hash_val];
 	deque_pop_selected_node(head, target_node);
-	tmp_deque_clear_node(&target_node, hash->del_value);
+	hash_deque_clear_node(&target_node, hash->del_value);
 	hash->key_count--;
 }

--- a/libft/srcs/ft_hash/hs_clear_table.c
+++ b/libft/srcs/ft_hash/hs_clear_table.c
@@ -8,8 +8,8 @@ void	hs_clear_elem(t_elem **elem, void (*del_value)(void *))
 	if (!elem || !*elem)
 		return ;
 	ft_free((*elem)->key);
-	del_value((*elem)->content);
-	(*elem)->content = NULL;
+	del_value((*elem)->value);
+	(*elem)->value = NULL;
 	ft_free(*elem);
 }
 
@@ -19,7 +19,7 @@ void	hs_clear_deque_node(t_deque_node **node, void (*del_value)(void *))
 
 	if (!*node)
 		return ;
-	elem = (*node)->content;
+	elem = (t_elem *)(*node)->content;
 	hs_clear_elem(&elem, del_value);
 	(*node)->next = NULL;
 	(*node)->prev = NULL;

--- a/libft/srcs/ft_hash/hs_clear_table.c
+++ b/libft/srcs/ft_hash/hs_clear_table.c
@@ -3,7 +3,7 @@
 #include "ft_hash.h"
 #include "ft_mem.h"
 
-void	clear_hash_elem(t_elem **elem, void (*del_value)(void *))
+void	hs_clear_elem(t_elem **elem, void (*del_value)(void *))
 {
 	if (!elem || !*elem)
 		return ;
@@ -13,20 +13,20 @@ void	clear_hash_elem(t_elem **elem, void (*del_value)(void *))
 	ft_free(*elem);
 }
 
-void	hash_deque_clear_node(t_deque_node **node, void (*del_value)(void *))
+void	hs_clear_deque_node(t_deque_node **node, void (*del_value)(void *))
 {
 	t_elem	*elem;
 
 	if (!*node)
 		return ;
 	elem = (*node)->content;
-	clear_hash_elem(&elem, del_value);
+	hs_clear_elem(&elem, del_value);
 	(*node)->next = NULL;
 	(*node)->prev = NULL;
 	ft_free(*node);
 }
 
-static void	hash_deque_clear_all(t_deque **deque, void (*del_value)(void *))
+static void	hash_clear_deque_all(t_deque **deque, void (*del_value)(void *))
 {
 	t_deque_node	*node;
 	t_deque_node	*tmp;
@@ -42,13 +42,13 @@ static void	hash_deque_clear_all(t_deque **deque, void (*del_value)(void *))
 	{
 		tmp = node;
 		node = node->next;
-		hash_deque_clear_node(&tmp, del_value);
+		hs_clear_deque_node(&tmp, del_value);
 	}
 	ft_free(*deque);
 	*deque = NULL;
 }
 
-void	clear_hash_table(t_hash **hash)
+void	hs_clear_table(t_hash **hash)
 {
 	size_t	idx;
 
@@ -58,7 +58,7 @@ void	clear_hash_table(t_hash **hash)
 	while (idx < (*hash)->table_size)
 	{
 		if ((*hash)->table[idx])
-			hash_deque_clear_all(&(*hash)->table[idx], (*hash)->del_value);
+			hash_clear_deque_all(&(*hash)->table[idx], (*hash)->del_value);
 		idx++;
 	}
 	free((*hash)->table);

--- a/libft/srcs/ft_hash/hs_create_table.c
+++ b/libft/srcs/ft_hash/hs_create_table.c
@@ -2,7 +2,7 @@
 #include "ft_hash.h"
 #include "ft_mem.h"
 
-t_hash	*create_hash_table(uint64_t size, void (*del_value)(void *))
+t_hash	*hs_create_table(uint64_t size, void (*del_value)(void *))
 {
 	t_hash	*hash;
 

--- a/libft/srcs/ft_hash/hs_delete_key.c
+++ b/libft/srcs/ft_hash/hs_delete_key.c
@@ -2,7 +2,7 @@
 #include "ft_deque.h"
 #include "ft_hash.h"
 
-void	delete_key_from_table(t_hash *hash, const char *key)
+void	hs_delete_key(t_hash *hash, const char *key)
 {
 	t_deque_node	*target_node;
 	uint64_t		hash_val;
@@ -10,12 +10,12 @@ void	delete_key_from_table(t_hash *hash, const char *key)
 
 	if (!hash || !key)
 		return ;
-	target_node = find_key(hash, key);
+	target_node = hs_find_key(hash, key);
 	if (!target_node)
 		return ;
-	hash_val = gen_fnv_hash((const unsigned char *)key, hash->table_size);
+	hash_val = hs_gen_fnv((const unsigned char *)key, hash->table_size);
 	head = hash->table[hash_val];
 	deque_pop_selected_node(head, target_node);
-	hash_deque_clear_node(&target_node, hash->del_value);
+	hs_clear_deque_node(&target_node, hash->del_value);
 	hash->key_count--;
 }

--- a/libft/srcs/ft_hash/hs_display.c
+++ b/libft/srcs/ft_hash/hs_display.c
@@ -27,7 +27,7 @@ static void	print_table_elem(t_deque *deque, void (*display)(void *))
 	}
 }
 
-void	display_hash_table(t_hash *hash, void (*display)(void *))
+void	hs_display(t_hash *hash, void (*display)(void *))
 {
 	size_t	idx;
 

--- a/libft/srcs/ft_hash/hs_find_key.c
+++ b/libft/srcs/ft_hash/hs_find_key.c
@@ -18,14 +18,14 @@ static t_deque_node	*find_key_in_deque(t_deque_node *node, const char *key)
 	return (NULL);
 }
 
-t_deque_node	*find_key(t_hash *hash, const char *key)
+t_deque_node	*hs_find_key(t_hash *hash, const char *key)
 {
 	uint64_t		hash_val;
 	t_deque_node	*addr;
 
 	if (!hash || !key)
 		return (NULL);
-	hash_val = gen_fnv_hash((const unsigned char *)key, hash->table_size);
+	hash_val = hs_gen_fnv((const unsigned char *)key, hash->table_size);
 	if (!hash->table[hash_val])
 		return (NULL);
 	if (!hash->table[hash_val]->size)

--- a/libft/srcs/ft_hash/hs_gen_fnv.c
+++ b/libft/srcs/ft_hash/hs_gen_fnv.c
@@ -9,7 +9,7 @@ static uint64_t	modulo_hash_mod(uint64_t hash, uint64_t hash_mod)
 }
 
 // return hash value
-uint64_t	gen_fnv_hash(const unsigned char *key, uint64_t hash_mod)
+uint64_t	hs_gen_fnv(const unsigned char *key, uint64_t hash_mod)
 {
 	static const uint64_t	prime = 1099511628211LLU;
 	static const uint64_t	offset = 14695981039346656037LLU;

--- a/libft/srcs/ft_hash/hs_get_value.c
+++ b/libft/srcs/ft_hash/hs_get_value.c
@@ -3,14 +3,14 @@
 
 // if 'key' found in table, return ptr of 'content',
 // otherwise, returns NULL, but content may be NULL
-void	*get_value_from_table(t_hash *hash, const char *key)
+void	*hs_get_value(t_hash *hash, const char *key)
 {
 	t_deque_node	*node;
 	t_elem			*elem;
 
 	if (!hash || !key)
 		return (NULL);
-	node = find_key(hash, key);
+	node = hs_find_key(hash, key);
 	if (!node)
 		return (NULL);
 	elem = node->content;

--- a/libft/srcs/ft_hash/hs_get_value.c
+++ b/libft/srcs/ft_hash/hs_get_value.c
@@ -1,8 +1,8 @@
 #include "ft_hash.h"
 #include "ft_deque.h"
 
-// if 'key' found in table, return ptr of 'content',
-// otherwise, returns NULL, but content may be NULL
+// if 'key' found in table, return ptr of 'value',
+// otherwise, returns NULL, but value may be NULL
 void	*hs_get_value(t_hash *hash, const char *key)
 {
 	t_deque_node	*node;
@@ -13,6 +13,6 @@ void	*hs_get_value(t_hash *hash, const char *key)
 	node = hs_find_key(hash, key);
 	if (!node)
 		return (NULL);
-	elem = node->content;
-	return (elem->content);
+	elem = (t_elem *)node->content;
+	return (elem->value);
 }

--- a/libft/srcs/ft_hash/hs_rehash_table.c
+++ b/libft/srcs/ft_hash/hs_rehash_table.c
@@ -11,7 +11,7 @@ bool	is_need_rehash(t_hash *hash)
 	return (true);
 }
 
-int	rehash_table(t_hash *hash)
+int	hs_rehash_table(t_hash *hash)
 {
 	(void)hash;
 

--- a/libft/srcs/ft_hash/hs_set_key.c
+++ b/libft/srcs/ft_hash/hs_set_key.c
@@ -4,7 +4,7 @@
 
 // if malloc error, return NULL
 // key != NULL
-static t_elem	*create_hash_elem(char *key, void *content)
+static t_elem	*create_hash_elem(char *key, void *value)
 {
 	t_elem	*elem;
 
@@ -12,7 +12,7 @@ static t_elem	*create_hash_elem(char *key, void *content)
 	if (!elem)
 		return (NULL);
 	elem->key = key;
-	elem->content = content;
+	elem->value = value;
 	return (elem);
 }
 
@@ -41,7 +41,7 @@ static int	add_elem_to_table(t_hash *hash, t_elem *elem, uint64_t hash_val)
 }
 
 // hash != NULL, key != NULL
-static int	add_to_table(t_hash *hash, char *key, void *content)
+static int	add_to_table(t_hash *hash, char *key, void *value)
 {
 	t_elem		*elem;
 	uint64_t	hash_val;
@@ -51,7 +51,7 @@ static int	add_to_table(t_hash *hash, char *key, void *content)
 	hash_val = hs_gen_fnv((const unsigned char *)key, hash->table_size);
 	if (alloc_deque_head(hash, hash_val) == HASH_ERROR)
 		return (HASH_ERROR);
-	elem = create_hash_elem(key, content);
+	elem = create_hash_elem(key, value);
 	if (!elem)
 		return (HASH_ERROR);
 	if (add_elem_to_table(hash, elem, hash_val) == HASH_ERROR)
@@ -65,7 +65,7 @@ static int	add_to_table(t_hash *hash, char *key, void *content)
 // if malloc error, return HASH_ERROR
 // hash not freed in func
 // 'key' cannot be null, 'value' can accept null
-int	hs_set_key(t_hash *hash, char *key, void *content)
+int	hs_set_key(t_hash *hash, char *key, void *value)
 {
 	t_deque_node	*target_node;
 
@@ -73,10 +73,10 @@ int	hs_set_key(t_hash *hash, char *key, void *content)
 		return (HASH_ERROR);
 	target_node = hs_find_key(hash, key);
 	if (target_node)
-		hs_update_value(&key, content, target_node, hash->del_value);
+		hs_update_value(&key, value, target_node, hash->del_value);
 	else
 	{
-		if (add_to_table(hash, key, content) == HASH_ERROR)
+		if (add_to_table(hash, key, value) == HASH_ERROR)
 			return (HASH_ERROR);
 		hash->key_count++;
 	}

--- a/libft/srcs/ft_hash/hs_set_key.c
+++ b/libft/srcs/ft_hash/hs_set_key.c
@@ -27,7 +27,7 @@ static int	alloc_deque_head(t_hash *hash, uint64_t hash_val)
 	return (HASH_SUCCESS);
 }
 
-// if deque_node_new malloc error, remain head t_deque(-> free clear_hash_table)
+// if deque_node_new malloc error, remain head t_deque(-> free hs_clear_table)
 // hash != NULL, elem != NULL
 static int	add_elem_to_table(t_hash *hash, t_elem *elem, uint64_t hash_val)
 {
@@ -46,9 +46,9 @@ static int	add_to_table(t_hash *hash, char *key, void *content)
 	t_elem		*elem;
 	uint64_t	hash_val;
 
-	if (is_need_rehash(hash) && rehash_table(hash) == HASH_ERROR)
+	if (is_need_rehash(hash) && hs_rehash_table(hash) == HASH_ERROR)
 		return (HASH_ERROR); // free hash by user
-	hash_val = gen_fnv_hash((const unsigned char *)key, hash->table_size);
+	hash_val = hs_gen_fnv((const unsigned char *)key, hash->table_size);
 	if (alloc_deque_head(hash, hash_val) == HASH_ERROR)
 		return (HASH_ERROR);
 	elem = create_hash_elem(key, content);
@@ -56,7 +56,7 @@ static int	add_to_table(t_hash *hash, char *key, void *content)
 		return (HASH_ERROR);
 	if (add_elem_to_table(hash, elem, hash_val) == HASH_ERROR)
 	{
-		clear_hash_elem(&elem, hash->del_value);
+		hs_clear_elem(&elem, hash->del_value);
 		return (HASH_ERROR);
 	}
 	return (HASH_SUCCESS);
@@ -65,15 +65,15 @@ static int	add_to_table(t_hash *hash, char *key, void *content)
 // if malloc error, return HASH_ERROR
 // hash not freed in func
 // 'key' cannot be null, 'value' can accept null
-int	set_to_table(t_hash *hash, char *key, void *content)
+int	hs_set_key(t_hash *hash, char *key, void *content)
 {
 	t_deque_node	*target_node;
 
 	if (!hash || !key)
 		return (HASH_ERROR);
-	target_node = find_key(hash, key);
+	target_node = hs_find_key(hash, key);
 	if (target_node)
-		update_content_of_key(&key, content, target_node, hash->del_value);
+		hs_update_value(&key, content, target_node, hash->del_value);
 	else
 	{
 		if (add_to_table(hash, key, content) == HASH_ERROR)

--- a/libft/srcs/ft_hash/hs_update_value.c
+++ b/libft/srcs/ft_hash/hs_update_value.c
@@ -4,7 +4,7 @@
 
 // key exist in hash
 // free(key, pre-content), update new content
-void	update_content_of_key(char **key, \
+void	hs_update_value(char **key, \
 								void *content, \
 								t_deque_node *target_node, \
 								void (*del_value)(void *))

--- a/libft/srcs/ft_hash/hs_update_value.c
+++ b/libft/srcs/ft_hash/hs_update_value.c
@@ -3,16 +3,16 @@
 #include "ft_mem.h"
 
 // key exist in hash
-// free(key, pre-content), update new content
+// free(key, pre-value), update new value
 void	hs_update_value(char **key, \
-								void *content, \
-								t_deque_node *target_node, \
-								void (*del_value)(void *))
+						void *value, \
+						t_deque_node *target_node, \
+						void (*del_value)(void *))
 {
 	t_elem	*elem;
 
 	ft_free(*key);
 	elem = (t_elem *)target_node->content;
-	del_value(elem->content);
-	elem->content = content;
+	del_value(elem->value);
+	elem->value = value;
 }

--- a/libft/srcs/ft_hash/set_key_to_table.c
+++ b/libft/srcs/ft_hash/set_key_to_table.c
@@ -41,10 +41,7 @@ static int	add_elem_to_table(t_hash *hash, t_elem *elem, uint64_t hash_val)
 }
 
 // hash != NULL, key != NULL
-static int	add_to_table(t_hash *hash, \
-							char *key, \
-							void *content, \
-							void (*del_content)(void *))
+static int	add_to_table(t_hash *hash, char *key, void *content)
 {
 	t_elem		*elem;
 	uint64_t	hash_val;
@@ -59,7 +56,7 @@ static int	add_to_table(t_hash *hash, \
 		return (HASH_ERROR);
 	if (add_elem_to_table(hash, elem, hash_val) == HASH_ERROR)
 	{
-		clear_hash_elem(&elem, del_content);
+		clear_hash_elem(&elem, hash->del_value);
 		return (HASH_ERROR);
 	}
 	return (HASH_SUCCESS);
@@ -68,10 +65,7 @@ static int	add_to_table(t_hash *hash, \
 // if malloc error, return HASH_ERROR
 // hash not freed in func
 // 'key' cannot be null, 'value' can accept null
-int	set_to_table(t_hash *hash, \
-					char *key, \
-					void *content, \
-					void (*del_content)(void *))
+int	set_to_table(t_hash *hash, char *key, void *content)
 {
 	t_deque_node	*target_node;
 
@@ -79,10 +73,10 @@ int	set_to_table(t_hash *hash, \
 		return (HASH_ERROR);
 	target_node = find_key(hash, key);
 	if (target_node)
-		update_content_of_key(&key, content, target_node, del_content);
+		update_content_of_key(&key, content, target_node, hash->del_value);
 	else
 	{
-		if (add_to_table(hash, key, content, del_content) == HASH_ERROR)
+		if (add_to_table(hash, key, content) == HASH_ERROR)
 			return (HASH_ERROR);
 		hash->key_count++;
 	}

--- a/libft/srcs/ft_hash/update_value.c
+++ b/libft/srcs/ft_hash/update_value.c
@@ -7,12 +7,12 @@
 void	update_content_of_key(char **key, \
 								void *content, \
 								t_deque_node *target_node, \
-								void (*del_content)(void *))
+								void (*del_value)(void *))
 {
 	t_elem	*elem;
 
 	ft_free(*key);
 	elem = (t_elem *)target_node->content;
-	del_content(elem->content);
+	del_value(elem->content);
 	elem->content = content;
 }

--- a/srcs/exec/child_process.c
+++ b/srcs/exec/child_process.c
@@ -1,6 +1,5 @@
 #include <stdlib.h>
 #include "minishell.h"
-#include "ms_builtin.h"
 #include "ms_exec.h"
 #include "ft_deque.h"
 #include "ft_dprintf.h"
@@ -11,7 +10,7 @@ static int	execute_builtin_command(t_command *cmd, t_params *params)
 	int			exec_status;
 
 	exec_status = call_builtin_command(command, params);
-	deque_clear_all(&cmd->head_command);
+	deque_clear_all(&cmd->head_command, free);
 	return (exec_status);
 }
 
@@ -25,7 +24,7 @@ static int	execute_external_command(t_command *cmd, char **environ)
 	{
 		ft_dprintf(STDERR_FILENO, "%s: %s: %s\n", \
 					SHELL_NAME, command[0], ERROR_MSG_CMD_NOT_FOUND);
-		deque_clear_all(&cmd->head_command);
+		deque_clear_all(&cmd->head_command, free);
 	}
 	return (EXIT_CODE_NO_SUCH_FILE);
 }

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -24,7 +24,7 @@ int	main(void)
 			return (EXIT_FAILURE);
 		// parse()
 		params.status = execute_command(command, &params);
-		deque_clear_all(&command);
+		deque_clear_all(&command, free);
 		if (params.status == PROCESS_ERROR)
 			return (EXIT_FAILURE);
 	}

--- a/test/unit_test/deque/test.c
+++ b/test/unit_test/deque/test.c
@@ -59,7 +59,7 @@ static void	pop_back_test(t_deque *deque)
 		return ;
 	}
 	printf("pop_back success: %s\n", (char *)pop_node->content);
-	deque_clear_node(&pop_node);
+	deque_clear_node(&pop_node, free);
 	debug_deque_print(deque, __func__);
 }
 
@@ -75,7 +75,7 @@ static void	pop_front_test(t_deque *deque)
 		return ;
 	}
 	printf("pop_front success: %s\n", (char *)pop_node->content);
-	deque_clear_node(&pop_node);
+	deque_clear_node(&pop_node, free);
 	debug_deque_print(deque, __func__);
 }
 
@@ -97,7 +97,7 @@ static void	pop_selected_node_test(t_deque *deque, size_t idx)
 	if (pop_node)
 	{
 		printf("pop_selected success: %s\n", (char *)pop_node->content);
-		deque_clear_node(&pop_node);
+		deque_clear_node(&pop_node, free);
 	}
 	debug_deque_print(deque, __func__);
 }
@@ -167,6 +167,6 @@ int	main(void)
 	pop_selected_node_test(deque, 0);
 	pop_selected_node_test(deque, 0);
 
-	deque_clear_all(&deque);
+	deque_clear_all(&deque, free);
 	return (EXIT_SUCCESS);
 }

--- a/test/unit_test/hash/test_hash.c
+++ b/test/unit_test/hash/test_hash.c
@@ -23,7 +23,7 @@ static void	display_table_info(t_hash *hash)
 {
 	printf("table size:%zu\n", hash->table_size);
 	printf("key count :%zu\n", hash->key_count);
-	display_hash_table(hash, display_elem);
+	hs_display(hash, display_elem);
 }
 
 static char *get_result_char(int res)
@@ -35,7 +35,7 @@ static char *get_result_char(int res)
 
 static int	test_hash_value(char *key, uint64_t mod, uint64_t expected, int no)
 {
-	uint64_t	hash =  gen_fnv_hash((const unsigned char *)key, mod);
+	uint64_t	hash =  hs_gen_fnv((const unsigned char *)key, mod);
 	printf("[%02d] %s\n", no, get_result_char(hash == expected));
 	printf("     key       :\"%s\"\n", key);
 	printf("     hash      :%lu\n", hash);
@@ -48,7 +48,7 @@ static int	test_hash_value(char *key, uint64_t mod, uint64_t expected, int no)
 
 static int	test_get_value(t_hash *hash, char *key, char *expected_val, int no)
 {
-	char	*value = (char *)get_value_from_table(hash, key);
+	char	*value = (char *)hs_get_value(hash, key);
 	int		res;
 
 	if (!value && !expected_val)
@@ -73,9 +73,9 @@ static void	del_elem_content_test(void *content)
 	free(value);
 }
 
-static void	test_delete_key_from_table(t_hash *hash, const char *key)
+static void	test_hs_delete_key(t_hash *hash, const char *key)
 {
-	delete_key_from_table(hash, key);
+	hs_delete_key(hash, key);
 }
 
 static void	set_to_table_by_allocated_strs(t_hash *hash, const char *s1, const char *s2)
@@ -87,7 +87,7 @@ static void	set_to_table_by_allocated_strs(t_hash *hash, const char *s1, const c
 		s1_dup = ft_strdup(s1);
 	if (s2)
 		s2_dup = ft_strdup(s2);
-	set_to_table(hash, s1_dup, s2_dup);
+	hs_set_key(hash, s1_dup, s2_dup);
 }
 
 int	main(void)
@@ -107,8 +107,8 @@ int	main(void)
 	{
 		printf("\n ========== hash table (except rehash) ==========\n");
 
-		t_hash	*hash = create_hash_table(100, del_elem_content_test);
-		display_hash_table(hash, display_elem);
+		t_hash	*hash = hs_create_table(100, del_elem_content_test);
+		hs_display(hash, display_elem);
 
 		set_to_table_by_allocated_strs(hash, "test_key", "test_value");
 		set_to_table_by_allocated_strs(hash, "pien", ";p");
@@ -132,22 +132,22 @@ int	main(void)
 		set_to_table_by_allocated_strs(hash, "abc", "abc5");
 		display_table_info(hash);
 
-		clear_hash_table(&hash);
+		hs_clear_table(&hash);
 
 		printf("\n\n");
 	}
 	{
 		printf("\n ===== hash table (use rehash) =====\n");
 
-		t_hash	*hash = create_hash_table(1, del_elem_content_test);
+		t_hash	*hash = hs_create_table(1, del_elem_content_test);
 		display_table_info(hash);
-		clear_hash_table(&hash);
+		hs_clear_table(&hash);
 		printf("\n\n");
 	}
 	{
 		printf("\n ===== find key =====\n");
 
-		t_hash	*hash = create_hash_table(100, del_elem_content_test);
+		t_hash	*hash = hs_create_table(100, del_elem_content_test);
 
 		set_to_table_by_allocated_strs(hash, "abc", "value of abc");
 		set_to_table_by_allocated_strs(hash, "abc1", "value of abc1");
@@ -177,16 +177,16 @@ int	main(void)
 
 		printf("\n   ----- after del key -----\n");
 		display_table_info(hash);
-		test_delete_key_from_table(hash, "abc1");
+		test_hs_delete_key(hash, "abc1");
 		display_table_info(hash);
-		test_delete_key_from_table(hash, "12345");
+		test_hs_delete_key(hash, "12345");
 		display_table_info(hash);
-		test_delete_key_from_table(hash, "not_exist_key");
+		test_hs_delete_key(hash, "not_exist_key");
 		display_table_info(hash);
-		test_delete_key_from_table(hash, "not_exist_key");
+		test_hs_delete_key(hash, "not_exist_key");
 		display_table_info(hash);
 
-		clear_hash_table(&hash);
+		hs_clear_table(&hash);
 		printf("\n\n");
 	}
 

--- a/test/unit_test/hash/test_hash.c
+++ b/test/unit_test/hash/test_hash.c
@@ -75,7 +75,7 @@ static void	del_elem_content_test(void *content)
 
 static void	test_delete_key_from_table(t_hash *hash, const char *key)
 {
-	delete_key_from_table(hash, key, del_elem_content_test);
+	delete_key_from_table(hash, key);
 }
 
 static void	set_to_table_by_allocated_strs(t_hash *hash, const char *s1, const char *s2)
@@ -87,7 +87,7 @@ static void	set_to_table_by_allocated_strs(t_hash *hash, const char *s1, const c
 		s1_dup = ft_strdup(s1);
 	if (s2)
 		s2_dup = ft_strdup(s2);
-	set_to_table(hash, s1_dup, s2_dup, del_elem_content_test);
+	set_to_table(hash, s1_dup, s2_dup);
 }
 
 int	main(void)
@@ -107,7 +107,7 @@ int	main(void)
 	{
 		printf("\n ========== hash table (except rehash) ==========\n");
 
-		t_hash	*hash = create_hash_table(100);
+		t_hash	*hash = create_hash_table(100, del_elem_content_test);
 		display_hash_table(hash, display_elem);
 
 		set_to_table_by_allocated_strs(hash, "test_key", "test_value");
@@ -132,22 +132,22 @@ int	main(void)
 		set_to_table_by_allocated_strs(hash, "abc", "abc5");
 		display_table_info(hash);
 
-		clear_hash_table(&hash, del_elem_content_test);
+		clear_hash_table(&hash);
 
 		printf("\n\n");
 	}
 	{
 		printf("\n ===== hash table (use rehash) =====\n");
 
-		t_hash	*hash = create_hash_table(1);
+		t_hash	*hash = create_hash_table(1, del_elem_content_test);
 		display_table_info(hash);
-		clear_hash_table(&hash, del_elem_content_test);
+		clear_hash_table(&hash);
 		printf("\n\n");
 	}
 	{
 		printf("\n ===== find key =====\n");
 
-		t_hash	*hash = create_hash_table(100);
+		t_hash	*hash = create_hash_table(100, del_elem_content_test);
 
 		set_to_table_by_allocated_strs(hash, "abc", "value of abc");
 		set_to_table_by_allocated_strs(hash, "abc1", "value of abc1");
@@ -186,7 +186,7 @@ int	main(void)
 		test_delete_key_from_table(hash, "not_exist_key");
 		display_table_info(hash);
 
-		clear_hash_table(&hash, del_elem_content_test);
+		clear_hash_table(&hash);
 		printf("\n\n");
 	}
 

--- a/test/unit_test/hash/test_hash.c
+++ b/test/unit_test/hash/test_hash.c
@@ -16,7 +16,7 @@ static void	display_elem(void *content)
 		return ;
 	elem = content;
 	ft_dprintf(STDERR_FILENO, "[\"%s\", \"%s\"]", \
-	elem->key, (char *)elem->content);
+	elem->key, (char *)elem->value);
 }
 
 static void	display_table_info(t_hash *hash)


### PR DESCRIPTION
- 関数ポインタ `del_value()` の渡し方を変更
- hash 系の関数名に `hs_` という prefix をつけた
- `t_elem->content` を `t_elem->value` にした

issus #122, PR #129