### PR TITLE
refactor of 149

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ SRCS		+=	$(BUILTIN_DIR)/ft_echo.c \
 				$(BUILTIN_DIR)/ft_env.c \
 				$(BUILTIN_DIR)/ft_exit.c \
 				$(BUILTIN_DIR)/ft_unset.c \
+				$(BUILTIN_DIR)/is_option.c \
 				$(BUILTIN_DIR)/str_to_legal_number.c
 
 ENVIRONMENT	:=	environment

--- a/includes/ms_builtin.h
+++ b/includes/ms_builtin.h
@@ -46,6 +46,7 @@ int		ft_env(char *const *argv, t_params *params);
 int		ft_exit(char *const *argv, t_params *params);
 int		ft_unset(char *const *argv, t_params *params);
 
+bool	is_option(const char *word);
 bool	str_to_legal_number(const char *str, long *result);
 
 #endif //MS_BUILTIN_H

--- a/srcs/builtin/ft_echo.c
+++ b/srcs/builtin/ft_echo.c
@@ -20,8 +20,6 @@ static bool	is_n_option(const char *arg)
 		return (false);
 	if (!is_option(arg))
 		return (false);
-	if (arg[1] != ECHO_OPTION)
-		return (false);
 	i = 1;
 	while (arg[i] == ECHO_OPTION)
 		i++;

--- a/srcs/builtin/ft_echo.c
+++ b/srcs/builtin/ft_echo.c
@@ -12,18 +12,20 @@
 //  {"echo", "-n" "-nnnnnnm", NULL}
 //                 ^^^^^^^^ NOT OPTION
 
-static bool	is_n_option(const char *str)
+static bool	is_n_option(const char *arg)
 {
 	size_t	i;
 
-	if (!str)
+	if (!arg)
 		return (false);
-	if (str[0] != CMD_OPTION_MARKER || str[1] != ECHO_OPTION)
+	if (!is_option(arg))
+		return (false);
+	if (arg[1] != ECHO_OPTION)
 		return (false);
 	i = 1;
-	while (str[i] == ECHO_OPTION)
+	while (arg[i] == ECHO_OPTION)
 		i++;
-	if (str[i])
+	if (arg[i])
 		return (false);
 	return (true);
 }
@@ -57,12 +59,12 @@ static void	put_strings(char *const *strs)
 int	ft_echo(char *const *argv)
 {
 	size_t	idx;
-	bool	is_n_op_validate;
+	bool	is_display_newline;
 
 	idx = 1;
-	skip_option_part(argv, &idx, &is_n_op_validate);
+	skip_option_part(argv, &idx, &is_display_newline);
 	put_strings(&argv[idx]);
-	if (!is_n_op_validate)
+	if (!is_display_newline)
 		ft_dprintf(STDOUT_FILENO, "\n");
 	return (EXIT_SUCCESS);
 }

--- a/srcs/builtin/ft_exit.c
+++ b/srcs/builtin/ft_exit.c
@@ -3,7 +3,6 @@
 #include "ms_builtin.h"
 #include "ms_exec.h"
 #include "ft_dprintf.h"
-#include "ft_string.h"
 
 // {"exit", "valid_arg", "invalid_arg1", "invalid_arg2", ..., NULL};
 

--- a/srcs/builtin/ft_unset.c
+++ b/srcs/builtin/ft_unset.c
@@ -1,4 +1,3 @@
-#include <stddef.h>
 #include "minishell.h"
 #include "ms_builtin.h"
 #include "ms_exec.h"

--- a/srcs/builtin/ft_unset.c
+++ b/srcs/builtin/ft_unset.c
@@ -2,10 +2,27 @@
 #include "ms_builtin.h"
 #include "ms_exec.h"
 
+static int	unset_args(t_env *env, char *const *args)
+{
+	int		status;
+	size_t	i;
+
+	status = SUCCESS;
+	i = 0;
+	while (args[i])
+	{
+		if (is_valid_key(args[i]))
+			env->unset(env, args[i]);
+		else
+			status = NOT_A_VALID_IDENTIFIER; // print error
+		i++;
+	}
+	return (status);
+}
+
 int	ft_unset(char *const *argv, t_params *params)
 {
 	const size_t	argc = count_argv(argv);
-	size_t			i;
 	int				status;
 
 	if (argc == 1)
@@ -15,15 +32,6 @@ int	ft_unset(char *const *argv, t_params *params)
 		status = INVALID_OPTION; // print error
 		return (status);
 	}
-	status = SUCCESS;
-	i = 1;
-	while (argv[i])
-	{
-		if (is_valid_key(argv[i]))
-			params->env->unset(params->env, argv[i]);
-		else
-			status = NOT_A_VALID_IDENTIFIER; // print error
-		i++;
-	}
+	status = unset_args(params->env, &argv[1]);
 	return (status);
 }

--- a/srcs/builtin/ft_unset.c
+++ b/srcs/builtin/ft_unset.c
@@ -2,11 +2,6 @@
 #include "ms_builtin.h"
 #include "ms_exec.h"
 
-static bool	is_option(const char *word)
-{
-	return (word[0] == '-' && word[1]);
-}
-
 int	ft_unset(char *const *argv, t_params *params)
 {
 	const size_t	argc = count_argv(argv);

--- a/srcs/builtin/is_option.c
+++ b/srcs/builtin/is_option.c
@@ -1,0 +1,6 @@
+#include "ms_builtin.h"
+
+bool	is_option(const char *word)
+{
+	return (word[0] == CMD_OPTION_MARKER && word[1]);
+}

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -3,7 +3,6 @@
 #include "ms_exec.h"
 #include "ms_tokenize.h"
 #include "ft_deque.h"
-#include "ft_dprintf.h"
 
 int	main(void)
 {


### PR DESCRIPTION
* #149 のrefactor
* #153 実装前にmergeしておきたい
* 変更点
  - 未使用のincludeを削除 4e9d15aea022ac2216138fb726a7d6b1215fa7cc 4e6f5e22265fe90daa40b07db1dc9bc369995a33
  - `is_option()` を独立（exportなどでも使用するため） 76ef5281e2289aa2841027c3a2e1b3c349afc815
  - `ft_unset()` の関数分割など f301def0ef63d5a5791b331b99bed0c3e999f578
  - `ft_echo()` で `is_option()` を使用 0e8ad251bb6812797a32a1c52ac881e555974454