### PR TITLE
refactor & fix

### DIFF
--- a/.github/workflows/norm.yml
+++ b/.github/workflows/norm.yml
@@ -16,6 +16,7 @@ jobs:
       - name: Install Norminette.
         run: |
           python3 -m pip install --upgrade pip setuptools
-          python3 -m pip install norminette
+          python3 -m pip install norminette==3.3.51
+          norminette --version
       - name: Norm check.
         run: python3 test/integration_test/norm.py

--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,10 @@ RL_FLAGS	:=	-lreadline
 MKDIR		:=	mkdir -p
 
 SRCS_DIR	:=	srcs
-SRCS		:=	init.c \
-				main.c
+SRCS		:=	destroy.c \
+				init.c \
+				main.c \
+				repl.c
 
 BUILTIN_DIR	:=	builtin
 SRCS		+=	$(BUILTIN_DIR)/ft_echo.c \

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -70,34 +70,40 @@ struct s_env
 
 // temporarily here ...
 /* debug */
-void	debug_func(const char *func_name, const int line_num);
-void	debug_2d_array(char **array);
-
-/* input */
-char	*input_line(void);
-
-/* init */
-void	init_params(t_params *params);
+void		debug_func(const char *func_name, const int line_num);
+void		debug_2d_array(char **array);
 
 /* environment */
 t_result	declare_arg(const char *const arg, t_env *env);
-char	*dup_env_key(const char *const arg, size_t *len);
-char	*dup_env_value(const char *const arg);
-char	*env_get_value(t_env *env, char *key);
-t_env	*init_environ(void);
-void	env_print_detail(t_env *env);
-void	env_print(t_env *env);
+char		*dup_env_key(const char *const arg, size_t *len);
+char		*dup_env_value(const char *const arg);
+char		*env_get_value(t_env *env, char *key);
+t_env		*init_environ(void);
+void		env_print_detail(t_env *env);
+void		env_print(t_env *env);
 t_result	separate_env_variables(const char *const arg, \
 								char **key, \
 								char **value, \
 								t_env_op *op);
-void	env_set(t_env *env, char *key, char *value, t_env_op op);
-void	env_unset(t_env *env, const char *key);
+void		env_set(t_env *env, char *key, char *value, t_env_op op);
+void		env_unset(t_env *env, const char *key);
+
+/* destroy */
+void		destroy(t_params params);
+
+/* input */
+char		*input_line(void);
 
 /* utils */
 // size_t	count_commands(char *const *commands);
-size_t	count_argv(const char *const *argc);
-void	ft_abort(void);
-bool	is_valid_key(const char *word);
+size_t		count_argv(const char *const *argc);
+void		ft_abort(void);
+bool		is_valid_key(const char *word);
+
+/* init */
+void		init_params(t_params *params);
+
+/* repl */
+t_result	read_eval_print_loop(t_params *params);
 
 #endif //MINISHELL_H

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -6,10 +6,14 @@
 # include <stdint.h>
 
 /* return value */
+# define CLOSE_ERROR	(-1)
+# define DUP_ERROR		(-1) // dup && dup2
 # define EXECVE_ERROR	(-1)
 # define FORK_ERROR		(-1)
-# define WAIT_ERROR		(-1)
+# define OPEN_ERROR		(-1)
 # define PIPE_ERROR		(-1)
+# define READ_ERROR		(-1)
+# define WAIT_ERROR		(-1)
 // # define PROCESS_ERROR	(-1)
 # define UNREACHABLE	(-1)
 
@@ -23,6 +27,7 @@
 # define SHELL_NAME		"minishell"
 # define PROMPT_NAME	"minishell "
 
+typedef enum e_result		t_result;
 typedef struct s_env		t_env;
 typedef struct s_hash_table	t_hash;
 
@@ -75,14 +80,14 @@ char	*input_line(void);
 void	init_params(t_params *params);
 
 /* environment */
-int		declare_arg(const char *const arg, t_env *env);
+t_result	declare_arg(const char *const arg, t_env *env);
 char	*dup_env_key(const char *const arg, size_t *len);
 char	*dup_env_value(const char *const arg);
 char	*env_get_value(t_env *env, char *key);
 t_env	*init_environ(void);
 void	env_print_detail(t_env *env);
 void	env_print(t_env *env);
-uint8_t	separate_env_variables(const char *const arg, \
+t_result	separate_env_variables(const char *const arg, \
 								char **key, \
 								char **value, \
 								t_env_op *op);

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -13,6 +13,7 @@
 # define PROCESS_ERROR	(-1)
 # define UNREACHABLE	(-1)
 
+// todo: typedef enum e_result??
 # define SUCCESS		0
 # define FAILURE		1
 # define CONTINUE		2
@@ -67,7 +68,7 @@ char	*input_line(void);
 void	init_params(t_params *params);
 
 /* environment */
-void	declare_arg(const char *const arg, t_env *env, uint8_t *status);
+int		declare_arg(const char *const arg, t_env *env);
 char	*dup_env_key(const char *const arg, size_t *len);
 char	*dup_env_value(const char *const arg);
 char	*env_get_value(t_env *env, char *key);

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -10,13 +10,8 @@
 # define FORK_ERROR		(-1)
 # define WAIT_ERROR		(-1)
 # define PIPE_ERROR		(-1)
-# define PROCESS_ERROR	(-1)
+// # define PROCESS_ERROR	(-1)
 # define UNREACHABLE	(-1)
-
-// todo: typedef enum e_result??
-# define SUCCESS		0
-# define FAILURE		1
-# define CONTINUE		2
 
 /* size */
 # define ENV_LIST_SIZE	256
@@ -30,6 +25,18 @@
 
 typedef struct s_env		t_env;
 typedef struct s_hash_table	t_hash;
+
+// # define SUCCESS	0
+// # define FAILURE	1
+// # define CONTINUE	2
+
+typedef enum e_result
+{
+	PROCESS_ERROR = -1,
+	SUCCESS = 0,
+	FAILURE = 1,
+	CONTINUE = 2,
+}	t_result;
 
 typedef enum e_env_op
 {

--- a/includes/ms_exec.h
+++ b/includes/ms_exec.h
@@ -14,6 +14,7 @@
 # define ERROR_MSG_NO_SUCH_FILE		"No such file or directory"
 # define ERROR_MSG_CMD_NOT_FOUND	"command not found"
 
+typedef enum e_result		t_result;
 typedef struct s_deque_node	t_deque_node;
 typedef struct s_deque		t_deque;
 typedef struct s_params		t_params;
@@ -37,14 +38,14 @@ bool			is_first_command(int prev_fd);
 bool			is_last_command(t_deque_node *next_cmd);
 
 /* child_process */
-int				handle_child_pipes(t_command *cmd, t_fd *fd);
+t_result		handle_child_pipes(t_command *cmd, t_fd *fd);
 void			child_process(t_command *cmd, \
 								t_fd *fd, \
 								char **environ, \
 								t_params *params);
 
 /* exec */
-int				execute_command(t_deque *dq_cmd, t_params *params);
+t_result		execute_command(t_deque *dq_cmd, t_params *params);
 t_deque_node	*get_next_command(t_deque_node *cmd, size_t *cmd_size);
 char			**convert_command_to_array(t_deque_node *cmd, \
 											const size_t size);
@@ -58,8 +59,8 @@ bool			is_command_builtin(const char *cmd);
 bool			is_single_builtin(t_deque_node *cmd);
 
 /* parent */
-int				handle_parent_pipes(t_command *cmd, t_fd *fd);
-int				parent_process(t_command *cmd, \
+t_result 		handle_parent_pipes(t_command *cmd, t_fd *fd);
+t_result 		parent_process(t_command *cmd, \
 								t_fd *fd, \
 								pid_t pid, \
 								uint8_t *last_status);

--- a/includes/ms_exec.h
+++ b/includes/ms_exec.h
@@ -44,9 +44,7 @@ void			child_process(t_command *cmd, \
 								t_params *params);
 
 /* exec */
-int				execute_command(t_deque *dq_cmd, \
-								uint8_t *status, \
-								t_params *params);
+int				execute_command(t_deque *dq_cmd, t_params *params);
 t_deque_node	*get_next_command(t_deque_node *cmd, size_t *cmd_size);
 char			**convert_command_to_array(t_deque_node *cmd, \
 											const size_t size);

--- a/includes/ms_exec.h
+++ b/includes/ms_exec.h
@@ -59,8 +59,8 @@ bool			is_command_builtin(const char *cmd);
 bool			is_single_builtin(t_deque_node *cmd);
 
 /* parent */
-t_result 		handle_parent_pipes(t_command *cmd, t_fd *fd);
-t_result 		parent_process(t_command *cmd, \
+t_result		handle_parent_pipes(t_command *cmd, t_fd *fd);
+t_result		parent_process(t_command *cmd, \
 								t_fd *fd, \
 								pid_t pid, \
 								uint8_t *last_status);

--- a/libft/srcs/ft_deque/dq_clear_all.c
+++ b/libft/srcs/ft_deque/dq_clear_all.c
@@ -8,7 +8,7 @@ void	deque_clear_all(t_deque **deque, void (*del)(void *))
 
 	if (deque_is_empty(*deque))
 	{
-		ft_free(*deque);
+		ft_free(deque);
 		return ;
 	}
 	node = (*deque)->node;
@@ -18,5 +18,5 @@ void	deque_clear_all(t_deque **deque, void (*del)(void *))
 		node = node->next;
 		deque_clear_node(&tmp, del);
 	}
-	ft_free(*deque);
+	ft_free(deque);
 }

--- a/libft/srcs/ft_deque/dq_clear_node.c
+++ b/libft/srcs/ft_deque/dq_clear_node.c
@@ -9,5 +9,5 @@ void	deque_clear_node(t_deque_node **node, void (*del)(void *))
 	(*node)->content = NULL;
 	(*node)->next = NULL;
 	(*node)->prev = NULL;
-	ft_free(*node);
+	ft_free(node);
 }

--- a/libft/srcs/ft_dprintf/handle_info.c
+++ b/libft/srcs/ft_dprintf/handle_info.c
@@ -47,7 +47,7 @@ void	clear_fmt_info(t_info_pf *info)
 
 void	free_dup_str(t_info_pf *info)
 {
-	ft_free(info->dup_str);
+	ft_free(&info->dup_str);
 }
 
 void	put_output(int fd, t_info_pf *info)
@@ -57,10 +57,10 @@ void	put_output(int fd, t_info_pf *info)
 	res = write(fd, info->output, info->index);
 	if (res == ERROR_WRITE || info->total_len + res >= INT_MAX)
 	{
-		ft_free(info->output);
+		ft_free(&info->output);
 		info->error = EXIT;
 		return ;
 	}
 	info->total_len += res;
-	ft_free(info->output);
+	ft_free(&info->output);
 }

--- a/libft/srcs/ft_hash/hs_clear.c
+++ b/libft/srcs/ft_hash/hs_clear.c
@@ -6,10 +6,10 @@ void	hs_clear_elem(t_elem **elem, void (*del_value)(void *))
 {
 	if (!elem || !*elem)
 		return ;
-	ft_free((*elem)->key);
+	ft_free(&(*elem)->key);
 	del_value((*elem)->value);
 	(*elem)->value = NULL;
-	ft_free(*elem);
+	ft_free(elem);
 }
 
 void	hs_clear_deque_node(t_deque_node **node, void (*del_value)(void *))
@@ -22,7 +22,7 @@ void	hs_clear_deque_node(t_deque_node **node, void (*del_value)(void *))
 	hs_clear_elem(&elem, del_value);
 	(*node)->next = NULL;
 	(*node)->prev = NULL;
-	ft_free(*node);
+	ft_free(node);
 }
 
 static void	hash_clear_deque_all(t_deque **deque, void (*del_value)(void *))
@@ -32,7 +32,7 @@ static void	hash_clear_deque_all(t_deque **deque, void (*del_value)(void *))
 
 	if (deque_is_empty(*deque))
 	{
-		ft_free(*deque);
+		ft_free(deque);
 		*deque = NULL;
 		return ;
 	}
@@ -43,7 +43,7 @@ static void	hash_clear_deque_all(t_deque **deque, void (*del_value)(void *))
 		node = node->next;
 		hs_clear_deque_node(&tmp, del_value);
 	}
-	ft_free(*deque);
+	ft_free(deque);
 	*deque = NULL;
 }
 
@@ -62,7 +62,7 @@ void	hs_clear_table(t_deque **table, \
 			hash_clear_deque_all(&table[idx], del_value);
 		idx++;
 	}
-	ft_free(table);
+	ft_free(&table);
 }
 
 void	hs_clear(t_hash **hash)
@@ -70,5 +70,5 @@ void	hs_clear(t_hash **hash)
 	if (!hash || !*hash)
 		return ;
 	hs_clear_table((*hash)->table, (*hash)->table_size, (*hash)->del_value);
-	ft_free(*hash);
+	ft_free(hash);
 }

--- a/libft/srcs/ft_hash/hs_create_table.c
+++ b/libft/srcs/ft_hash/hs_create_table.c
@@ -18,7 +18,7 @@ t_hash	*hs_create_table(size_t size, void (*del_value)(void *))
 	hash->table = (t_deque **)ft_calloc(hash->table_size, sizeof(t_deque *));
 	if (!hash->table)
 	{
-		ft_free(hash);
+		ft_free(&hash);
 		return (NULL);
 	}
 	hash->del_value = del_value;

--- a/libft/srcs/ft_hash/hs_update_value.c
+++ b/libft/srcs/ft_hash/hs_update_value.c
@@ -11,7 +11,7 @@ void	hs_update_value(char **key, \
 {
 	t_elem	*elem;
 
-	ft_free(*key);
+	ft_free(key);
 	elem = (t_elem *)target_node->content;
 	del_value(elem->value);
 	elem->value = value;

--- a/libft/srcs/ft_list/ft_lstdelone.c
+++ b/libft/srcs/ft_list/ft_lstdelone.c
@@ -7,5 +7,5 @@ void	ft_lstdelone(t_list *lst, void (*del)(void*))
 		return ;
 	if (del)
 		del(lst->content);
-	ft_free(lst);
+	ft_free(&lst);
 }

--- a/libft/srcs/ft_mem/ft_free.c
+++ b/libft/srcs/ft_mem/ft_free.c
@@ -1,17 +1,12 @@
 #include <stdlib.h>
 
-static void	*ft_free_sub(void **ptr)
-{
-	free(*ptr);
-	*ptr = NULL;
-	return (NULL);
-}
-
-void	*ft_free(void *ptr)
+void	*ft_free(void **ptr)
 {
 	if (!ptr)
 		return (NULL);
-	return (ft_free_sub(&ptr));
+	free(*ptr);
+	*ptr = NULL;
+	return (NULL);
 }
 
 void	*free_2d_array(char ***ptr)
@@ -23,9 +18,9 @@ void	*free_2d_array(char ***ptr)
 	i = 0;
 	while ((*ptr)[i])
 	{
-		ft_free((*ptr)[i]);
+		ft_free((void **)&(*ptr)[i]);
 		i++;
 	}
-	ft_free(*ptr);
+	ft_free((void **)ptr);
 	return (NULL);
 }

--- a/srcs/builtin/ft_echo.c
+++ b/srcs/builtin/ft_echo.c
@@ -57,9 +57,9 @@ static void	put_strings(const char *const *strs)
 // argv[0] == "echo"
 uint8_t	ft_echo(const char *const *argv)
 {
+	uint8_t	status;
 	size_t	idx;
 	bool	is_display_newline;
-	uint8_t	status;
 
 	status = EXIT_SUCCESS;
 	idx = 1;

--- a/srcs/builtin/ft_echo.c
+++ b/srcs/builtin/ft_echo.c
@@ -59,11 +59,13 @@ uint8_t	ft_echo(const char *const *argv)
 {
 	size_t	idx;
 	bool	is_display_newline;
+	uint8_t	status;
 
+	status = EXIT_SUCCESS;
 	idx = 1;
 	skip_option_part(argv, &idx, &is_display_newline);
 	put_strings(&argv[idx]);
 	if (!is_display_newline)
 		ft_dprintf(STDOUT_FILENO, "\n");
-	return (EXIT_SUCCESS);
+	return (status);
 }

--- a/srcs/builtin/ft_env.c
+++ b/srcs/builtin/ft_env.c
@@ -6,8 +6,8 @@
 // {"env", "arg1", "arg2", ..., NULL};
 uint8_t	ft_env(const char *const *argv, t_params *params)
 {
-	const size_t	argc = count_argv(argv);
 	uint8_t			status;
+	const size_t	argc = count_argv(argv);
 
 	status = EXIT_SUCCESS;
 	if (argc != 1)

--- a/srcs/builtin/ft_env.c
+++ b/srcs/builtin/ft_env.c
@@ -1,3 +1,4 @@
+#include <stdlib.h>
 #include "minishell.h"
 #include "ms_builtin.h"
 #include "ms_exec.h"
@@ -6,12 +7,15 @@
 uint8_t	ft_env(const char *const *argv, t_params *params)
 {
 	const size_t	argc = count_argv(argv);
+	uint8_t			status;
 
+	status = EXIT_SUCCESS;
 	if (argc != 1)
 	{
 		// todo : error handring
-		return (FAILURE);
+		status = INVALID_OPTION; // print error
+		return (status);
 	}
 	params->env->print(params->env);
-	return (SUCCESS);
+	return (status);
 }

--- a/srcs/builtin/ft_export.c
+++ b/srcs/builtin/ft_export.c
@@ -6,11 +6,19 @@
 static void	declare_all(const char *const *args, t_env *env, uint8_t *status)
 {
 	size_t	i;
+	int		result;
 
 	i = 0;
 	while (args[i])
 	{
-		declare_arg(args[i], env, status);
+		result = declare_arg(args[i], env);
+		if (result == FAILURE)
+		{
+			*status = NOT_A_VALID_IDENTIFIER;
+			// todo: func
+			ft_dprintf(STDERR_FILENO, "%s: %s: %s: %s\n", \
+				SHELL_NAME, CMD_EXPORT, args[i], ERROR_MSG_NOT_VALID_ID);
+		}
 		i++;
 	}
 }

--- a/srcs/builtin/ft_export.c
+++ b/srcs/builtin/ft_export.c
@@ -5,7 +5,7 @@
 
 static void	declare_all(const char *const *args, t_env *env, uint8_t *status)
 {
-	size_t	i;
+	size_t		i;
 	t_result	result;
 
 	i = 0;

--- a/srcs/builtin/ft_export.c
+++ b/srcs/builtin/ft_export.c
@@ -6,7 +6,7 @@
 static void	declare_all(const char *const *args, t_env *env, uint8_t *status)
 {
 	size_t	i;
-	int		result;
+	t_result	result;
 
 	i = 0;
 	while (args[i])

--- a/srcs/builtin/ft_unset.c
+++ b/srcs/builtin/ft_unset.c
@@ -1,3 +1,4 @@
+#include <stdlib.h>
 #include "minishell.h"
 #include "ms_builtin.h"
 #include "ms_exec.h"
@@ -6,7 +7,6 @@ static void	unset_args(const char *const *args, t_env *env, uint8_t *status)
 {
 	size_t	i;
 
-	*status = SUCCESS;
 	i = 0;
 	while (args[i])
 	{
@@ -23,8 +23,9 @@ uint8_t	ft_unset(const char *const *argv, t_params *params)
 	const size_t	argc = count_argv(argv);
 	uint8_t			status;
 
+	status = EXIT_SUCCESS;
 	if (argc == 1)
-		return (SUCCESS);
+		return (status);
 	if (is_option(argv[1]))
 	{
 		status = INVALID_OPTION; // print error

--- a/srcs/destroy.c
+++ b/srcs/destroy.c
@@ -1,0 +1,11 @@
+#include <readline/readline.h>
+#include "minishell.h"
+#include "ft_hash.h"
+#include "ft_mem.h"
+
+void	destroy(t_params params)
+{
+	hs_clear(&params.env->hash);
+	ft_free(params.env);
+	rl_clear_history();
+}

--- a/srcs/destroy.c
+++ b/srcs/destroy.c
@@ -6,6 +6,6 @@
 void	destroy(t_params params)
 {
 	hs_clear(&params.env->hash);
-	ft_free(params.env);
+	ft_free(&params.env);
 	rl_clear_history();
 }

--- a/srcs/environment/declare_arg.c
+++ b/srcs/environment/declare_arg.c
@@ -2,7 +2,7 @@
 
 t_result	declare_arg(const char *const arg, t_env *env)
 {
-	t_result 	result;
+	t_result	result;
 	char		*key;
 	char		*value;
 	t_env_op	op;

--- a/srcs/environment/declare_arg.c
+++ b/srcs/environment/declare_arg.c
@@ -1,8 +1,8 @@
 #include "minishell.h"
 
-int	declare_arg(const char *const arg, t_env *env)
+t_result	declare_arg(const char *const arg, t_env *env)
 {
-	int			result;
+	t_result 	result;
 	char		*key;
 	char		*value;
 	t_env_op	op;
@@ -11,5 +11,5 @@ int	declare_arg(const char *const arg, t_env *env)
 	if (result == FAILURE || result == CONTINUE)
 		return (result);
 	env->set(env, key, value, op);
-	return (SUCCESS);
+	return (result);
 }

--- a/srcs/environment/declare_arg.c
+++ b/srcs/environment/declare_arg.c
@@ -1,6 +1,4 @@
 #include "minishell.h"
-#include "ms_builtin.h"
-#include "ft_dprintf.h"
 
 int	declare_arg(const char *const arg, t_env *env)
 {

--- a/srcs/environment/declare_arg.c
+++ b/srcs/environment/declare_arg.c
@@ -2,7 +2,7 @@
 #include "ms_builtin.h"
 #include "ft_dprintf.h"
 
-void	declare_arg(const char *const arg, t_env *env, uint8_t *status)
+int	declare_arg(const char *const arg, t_env *env)
 {
 	int			result;
 	char		*key;
@@ -10,14 +10,8 @@ void	declare_arg(const char *const arg, t_env *env, uint8_t *status)
 	t_env_op	op;
 
 	result = separate_env_variables(arg, &key, &value, &op);
-	if (result == FAILURE)
-	{
-		*status = NOT_A_VALID_IDENTIFIER;
-		ft_dprintf(STDERR_FILENO, "%s: %s: %s: %s\n", \
-			SHELL_NAME, CMD_EXPORT, arg, ERROR_MSG_NOT_VALID_ID); // todo: func
-		return ;
-	}
-	if (result == CONTINUE)
-		return ;
+	if (result == FAILURE || result == CONTINUE)
+		return (result);
 	env->set(env, key, value, op);
+	return (SUCCESS);
 }

--- a/srcs/environment/init.c
+++ b/srcs/environment/init.c
@@ -8,7 +8,7 @@ static void	del_env_val(void *value)
 	char	*val;
 
 	val = value;
-	ft_free(val);
+	ft_free(&val);
 }
 
 static void	set_func(t_env *env)

--- a/srcs/environment/init.c
+++ b/srcs/environment/init.c
@@ -20,15 +20,18 @@ static void	set_func(t_env *env)
 	env->print_detail = env_print_detail;
 }
 
+// if init_environ() -> declare_arg() returns FAILURE, nothing happen & skip.
 static void	get_environ(t_env *env)
 {
 	extern char	**environ;
 	size_t		i;
 
 	i = 0;
+	if (!environ)
+		return ;
 	while (environ[i])
 	{
-		declare_arg(environ[i], env, NULL);
+		declare_arg(environ[i], env);
 		i++;
 	}
 }

--- a/srcs/environment/print_detail.c
+++ b/srcs/environment/print_detail.c
@@ -102,5 +102,5 @@ void	env_print_detail(t_env *env)
 	set_elem_pointer(elems, env->hash->table, env->hash->table_size);
 	sort_elems_by_key(elems);
 	print_elems(elems);
-	free(elems);
+	ft_free(elems);
 }

--- a/srcs/environment/print_detail.c
+++ b/srcs/environment/print_detail.c
@@ -102,5 +102,5 @@ void	env_print_detail(t_env *env)
 	set_elem_pointer(elems, env->hash->table, env->hash->table_size);
 	sort_elems_by_key(elems);
 	print_elems(elems);
-	ft_free(elems);
+	ft_free(&elems);
 }

--- a/srcs/environment/separate_env_variables.c
+++ b/srcs/environment/separate_env_variables.c
@@ -50,11 +50,11 @@ static t_result	validate_env_key(char *key)
 // key+=      -> key  ""     += (JOIN)
 // key        -> key  NULL      (ADD)
 t_result	separate_env_variables(const char *const arg, \
-								char **key, \
-								char **value, \
-								t_env_op *op)
+									char **key, \
+									char **value, \
+									t_env_op *op)
 {
-	size_t	i;
+	size_t		i;
 	t_result	result;
 
 	*key = dup_env_key(arg, &i);

--- a/srcs/environment/separate_env_variables.c
+++ b/srcs/environment/separate_env_variables.c
@@ -33,7 +33,7 @@ static t_env_op	get_env_op(const char *const arg, size_t *i)
 //  key is `name` ? -> true : status=0, return SUCCESS(0)
 //                     false: status=2, return FAILURE(1)
 //      is `_`      ->        status=0, return CONTINUE(2)
-static uint8_t	validate_env_key(char *key)
+static t_result	validate_env_key(char *key)
 {
 	if (!is_valid_key(key))
 		return (FAILURE);
@@ -49,13 +49,13 @@ static uint8_t	validate_env_key(char *key)
 // key+=value -> key  value  += (JOIN)
 // key+=      -> key  ""     += (JOIN)
 // key        -> key  NULL      (ADD)
-uint8_t	separate_env_variables(const char *const arg, \
+t_result	separate_env_variables(const char *const arg, \
 								char **key, \
 								char **value, \
 								t_env_op *op)
 {
 	size_t	i;
-	uint8_t	result;
+	t_result	result;
 
 	*key = dup_env_key(arg, &i);
 	result = validate_env_key(*key);
@@ -66,5 +66,5 @@ uint8_t	separate_env_variables(const char *const arg, \
 	}
 	*op = get_env_op(arg, &i);
 	*value = dup_env_value(&arg[i]);
-	return (SUCCESS);
+	return (result);
 }

--- a/srcs/environment/separate_env_variables.c
+++ b/srcs/environment/separate_env_variables.c
@@ -61,7 +61,7 @@ t_result	separate_env_variables(const char *const arg, \
 	result = validate_env_key(*key);
 	if (result == FAILURE || result == CONTINUE)
 	{
-		ft_free(*key);
+		ft_free(key);
 		return (result);
 	}
 	*op = get_env_op(arg, &i);

--- a/srcs/environment/set.c
+++ b/srcs/environment/set.c
@@ -11,7 +11,7 @@ static void	env_add(t_env *env, char *key, char *value, t_deque_node *node)
 {
 	if (!value)
 	{
-		ft_free(key);
+		ft_free(&key);
 		return ;
 	}
 	hs_update_value(&key, value, node, env->hash->del_value);
@@ -37,7 +37,7 @@ static void	env_join(t_env *env, char *key, char *new_value, t_deque_node *node)
 	elem = (t_elem *)node->content;
 	joined_value = join_new_value(elem->value, new_value);
 	hs_update_value(&key, joined_value, node, env->hash->del_value);
-	ft_free(new_value);
+	ft_free(&new_value);
 }
 
 void	env_set(t_env *env, char *key, char *value, t_env_op op)

--- a/srcs/exec/child_pipes.c
+++ b/srcs/exec/child_pipes.c
@@ -2,31 +2,32 @@
 #include "ms_exec.h"
 #include "ft_sys.h"
 
-static int	handle_child_pipes_except_first(t_fd *fd)
+static t_result	handle_child_pipes_except_first(t_fd *fd)
 {
-	if (x_close(STDIN_FILENO) == PROCESS_ERROR)
+	if (x_close(STDIN_FILENO) == CLOSE_ERROR)
 		return (PROCESS_ERROR);
-	if (x_dup2(fd->prev_fd, STDIN_FILENO) == PROCESS_ERROR)
+	if (x_dup2(fd->prev_fd, STDIN_FILENO) == DUP_ERROR)
 		return (PROCESS_ERROR);
-	if (x_close(fd->prev_fd) == PROCESS_ERROR)
+	if (x_close(fd->prev_fd) == CLOSE_ERROR)
 		return (PROCESS_ERROR);
-	return (EXIT_SUCCESS);
+	return (SUCCESS);
 }
 
-static int	handle_child_pipes_except_last(t_fd *fd)
+static t_result	handle_child_pipes_except_last(t_fd *fd)
 {
-	if (x_close(fd->pipefd[READ]) == PROCESS_ERROR)
+	if (x_close(fd->pipefd[READ]) == CLOSE_ERROR)
 		return (PROCESS_ERROR);
-	if (x_close(STDOUT_FILENO) == PROCESS_ERROR)
+	if (x_close(STDOUT_FILENO) == CLOSE_ERROR)
 		return (PROCESS_ERROR);
-	if (x_dup2(fd->pipefd[WRITE], STDOUT_FILENO) == PROCESS_ERROR)
+	if (x_dup2(fd->pipefd[WRITE], STDOUT_FILENO) == DUP_ERROR)
 		return (PROCESS_ERROR);
-	if (x_close(fd->pipefd[WRITE]) == PROCESS_ERROR)
+	if (x_close(fd->pipefd[WRITE]) == CLOSE_ERROR)
 		return (PROCESS_ERROR);
-	return (EXIT_SUCCESS);
+	return (SUCCESS);
 }
 
-int	handle_child_pipes(t_command *cmd, t_fd *fd)
+//todo:fds?
+t_result	handle_child_pipes(t_command *cmd, t_fd *fd)
 {
 	if (!is_first_command(fd->prev_fd))
 	{
@@ -38,5 +39,5 @@ int	handle_child_pipes(t_command *cmd, t_fd *fd)
 		if (handle_child_pipes_except_last(fd) == PROCESS_ERROR)
 			return (PROCESS_ERROR);
 	}
-	return (EXIT_SUCCESS);
+	return (SUCCESS);
 }

--- a/srcs/exec/child_process.c
+++ b/srcs/exec/child_process.c
@@ -19,8 +19,9 @@ static uint8_t	execute_external_command(t_command *cmd, char **environ)
 	char *const	*argv = cmd->exec_command;
 	int			exec_status;
 
-	exec_status = execve(argv[0], argv, environ);
-	if (exec_status == EXECVE_ERROR)
+	if (argv[0])
+		exec_status = execve(argv[0], argv, environ);
+	if (!argv[0] || exec_status == EXECVE_ERROR)
 	{
 		ft_dprintf(STDERR_FILENO, "%s: %s: %s\n", \
 					SHELL_NAME, argv[0], ERROR_MSG_CMD_NOT_FOUND);

--- a/srcs/exec/exec.c
+++ b/srcs/exec/exec.c
@@ -17,7 +17,7 @@ static void	exec_builtin_in_parent_proc(t_command cmd, \
 	free_2d_array(&cmd.exec_command);
 }
 
-static int	dup_process_and_run(t_command *cmd, \
+static t_result	dup_process_and_run(t_command *cmd, \
 								t_fd *fd, \
 								uint8_t *last_status, \
 								t_params *params)
@@ -28,11 +28,11 @@ static int	dup_process_and_run(t_command *cmd, \
 	if (!is_last_command(cmd->next_command))
 	{
 		if (x_pipe(fd->pipefd) == PIPE_ERROR)
-			return (PIPE_ERROR);
+			return (PROCESS_ERROR);
 	}
 	pid = x_fork();
 	if (pid == FORK_ERROR)
-		return (FORK_ERROR);
+		return (PROCESS_ERROR);
 	params->is_interactive = false;
 	if (pid == CHILD_PID)
 		child_process(cmd, fd, environ, params);
@@ -41,10 +41,10 @@ static int	dup_process_and_run(t_command *cmd, \
 		if (parent_process(cmd, fd, pid, last_status) == PROCESS_ERROR)
 			return (PROCESS_ERROR);
 	}
-	return (EXIT_SUCCESS);
+	return (SUCCESS);
 }
 
-int	execute_command(t_deque *dq_cmd, t_params *params)
+t_result	execute_command(t_deque *dq_cmd, t_params *params)
 {
 	t_command		cmd;
 	t_fd			fd;

--- a/srcs/exec/exec.c
+++ b/srcs/exec/exec.c
@@ -4,19 +4,17 @@
 #include "ft_mem.h"
 #include "ft_sys.h"
 
-static uint8_t	exec_builtin_in_parent_proc(t_command cmd, \
+static void	exec_builtin_in_parent_proc(t_command cmd, \
 										t_deque_node *exec_cmd, \
 										t_params *params)
 {
-	uint8_t	status;
 	size_t	cmd_size;
 
 	cmd.next_command = get_next_command(exec_cmd, &cmd_size);
 	cmd.exec_command = convert_command_to_array(exec_cmd, cmd_size);
-	status = call_builtin_command((const char *const *)cmd.exec_command, \
+	params->status = call_builtin_command((const char *const *)cmd.exec_command, \
 									params);
 	free_2d_array(&cmd.exec_command);
-	return (status);
 }
 
 static int	dup_process_and_run(t_command *cmd, \
@@ -56,10 +54,13 @@ int	execute_command(t_deque *dq_cmd, t_params *params)
 
 	init_cmd(&cmd, dq_cmd);
 	init_fd(&fd);
-	last_status = EXIT_SUCCESS;
 	exec_cmd = dq_cmd->node;
 	if (is_single_builtin(exec_cmd))
-		return (exec_builtin_in_parent_proc(cmd, exec_cmd, params));
+	{
+		exec_builtin_in_parent_proc(cmd, exec_cmd, params);
+		return (SUCCESS);
+	}
+	last_status = EXIT_SUCCESS;
 	while (exec_cmd)
 	{
 		cmd.next_command = get_next_command(exec_cmd, &cmd_size);

--- a/srcs/exec/exec.c
+++ b/srcs/exec/exec.c
@@ -46,7 +46,7 @@ static int	dup_process_and_run(t_command *cmd, \
 	return (EXIT_SUCCESS);
 }
 
-int	execute_command(t_deque *dq_cmd, uint8_t *status, t_params *params)
+int	execute_command(t_deque *dq_cmd, t_params *params)
 {
 	t_command		cmd;
 	t_fd			fd;
@@ -70,6 +70,6 @@ int	execute_command(t_deque *dq_cmd, uint8_t *status, t_params *params)
 		free_2d_array(&cmd.exec_command);
 		exec_cmd = cmd.next_command;
 	}
-	*status = last_status;
+	params->status = last_status;
 	return (SUCCESS);
 }

--- a/srcs/exec/get_exec_command.c
+++ b/srcs/exec/get_exec_command.c
@@ -1,6 +1,7 @@
 #include "minishell.h"
 #include "ft_deque.h"
 #include "ft_string.h"
+#include "ft_mem.h"
 #include "ft_sys.h"
 
 // | command                  -> not handle yet
@@ -17,8 +18,7 @@ t_deque_node	*get_next_command(t_deque_node *cmd, size_t *cmd_size)
 	}
 	if (cmd)
 	{
-		free(cmd->content);
-		cmd->content = NULL;
+		ft_free(cmd->content); // todo: del_elem??
 		cmd = cmd->next;
 	}
 	return (cmd);

--- a/srcs/exec/get_exec_command.c
+++ b/srcs/exec/get_exec_command.c
@@ -18,7 +18,9 @@ t_deque_node	*get_next_command(t_deque_node *cmd, size_t *cmd_size)
 	}
 	if (cmd)
 	{
-		ft_free(cmd->content); // todo: del_elem??
+		// todo : ft_free -> valgrind error...
+		free(cmd->content);
+		cmd->content = NULL;
 		cmd = cmd->next;
 	}
 	return (cmd);

--- a/srcs/exec/parent_pipes.c
+++ b/srcs/exec/parent_pipes.c
@@ -2,22 +2,22 @@
 #include "ms_exec.h"
 #include "ft_sys.h"
 
-static int	handle_parent_pipes_except_first(t_fd *fd)
+static t_result	handle_parent_pipes_except_first(t_fd *fd)
 {
-	if (x_close(fd->prev_fd) == PROCESS_ERROR)
+	if (x_close(fd->prev_fd) == CLOSE_ERROR)
 		return (PROCESS_ERROR);
-	return (EXIT_SUCCESS);
+	return (SUCCESS);
 }
 
-static int	handle_parent_pipes_except_last(t_fd *fd)
+static t_result	handle_parent_pipes_except_last(t_fd *fd)
 {
 	fd->prev_fd = fd->pipefd[READ];
-	if (x_close(fd->pipefd[WRITE]) == PROCESS_ERROR)
+	if (x_close(fd->pipefd[WRITE]) == CLOSE_ERROR)
 		return (PROCESS_ERROR);
-	return (EXIT_SUCCESS);
+	return (SUCCESS);
 }
 
-int	handle_parent_pipes(t_command *cmd, t_fd *fd)
+t_result	handle_parent_pipes(t_command *cmd, t_fd *fd)
 {
 	if (!is_first_command(fd->prev_fd))
 	{
@@ -29,5 +29,5 @@ int	handle_parent_pipes(t_command *cmd, t_fd *fd)
 		if (handle_parent_pipes_except_last(fd) == PROCESS_ERROR)
 			return (PROCESS_ERROR);
 	}
-	return (EXIT_SUCCESS);
+	return (SUCCESS);
 }

--- a/srcs/exec/parent_process.c
+++ b/srcs/exec/parent_process.c
@@ -4,39 +4,44 @@
 #include "ms_exec.h"
 #include "ft_sys.h"
 
-static int	get_last_command_status(pid_t pid, \
+static t_result	get_last_command_status(pid_t pid, \
 									int *wait_status, \
 									uint8_t *last_status)
 {
 	pid_t	wait_pid;
 
 	wait_pid = x_waitpid(pid, wait_status, 0);
-	if (wait_pid != PROCESS_ERROR && WIFEXITED(*wait_status))
+	if (wait_pid != WAIT_ERROR && WIFEXITED(*wait_status))
 		*last_status = WEXITSTATUS(*wait_status);
 	else
-		return (WAIT_ERROR);
-	return (EXIT_SUCCESS);
+		return (PROCESS_ERROR);
+	return (SUCCESS);
 }
 
 // if wait error, no need for auto perror.
-static int	wait_all_child_process(int wait_status)
+static t_result	wait_all_child_process(int wait_status)
 {
 	while (true)
 	{
+		errno = 0;
 		if (wait(NULL) != WAIT_ERROR)
 			continue ;
 		if (errno == ECHILD && WIFEXITED(wait_status))
-			return (EXIT_SUCCESS);
+			break ;
 		else
 		{
 			perror("wait");
 			return (PROCESS_ERROR);
 		}
 	}
-	return (EXIT_SUCCESS);
+	return (SUCCESS);
 }
 
-int	parent_process(t_command *cmd, t_fd *fd, pid_t pid, uint8_t *last_status)
+//todo fd->fds?
+t_result	parent_process(t_command *cmd, \
+							t_fd *fd, \
+							pid_t pid, \
+							uint8_t *last_status)
 {
 	int	wait_status;
 
@@ -50,5 +55,5 @@ int	parent_process(t_command *cmd, t_fd *fd, pid_t pid, uint8_t *last_status)
 		if (wait_all_child_process(wait_status) == PROCESS_ERROR)
 			return (PROCESS_ERROR);
 	}
-	return (EXIT_SUCCESS);
+	return (SUCCESS);
 }

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -1,3 +1,4 @@
+#include <readline/readline.h>
 #include <stdlib.h>
 #include "minishell.h"
 #include "ms_exec.h"
@@ -27,5 +28,6 @@ int	main(void)
 	}
 	hs_clear(&params.env->hash);
 	ft_free(params.env);
+	rl_clear_history();
 	return (params.status);
 }

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -11,10 +11,8 @@ int	main(void)
 	t_params	params;
 	t_deque		*command;
 	char		*line;
-	uint8_t		*status;
 
 	init_params(&params);
-	status = &params.status;
 	command = NULL;
 	while (true)
 	{
@@ -23,11 +21,11 @@ int	main(void)
 			break ;
 		command = tokenize(line);
 		ft_free(line);
-		if (execute_command(command, status, &params) == PROCESS_ERROR)
+		if (execute_command(command, &params) == PROCESS_ERROR)
 			return (EXIT_FAILURE);
 		deque_clear_all(&command, free);
 	}
 	hs_clear(&params.env->hash);
 	ft_free(params.env);
-	return (*status);
+	return (params.status);
 }

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -22,7 +22,7 @@ int	main(void)
 		if (!line)
 			break ;
 		command = tokenize(line);
-		free(line);
+		ft_free(line);
 		if (execute_command(command, status, &params) == PROCESS_ERROR)
 			return (EXIT_FAILURE);
 		deque_clear_all(&command, free);

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -1,33 +1,15 @@
-#include <readline/readline.h>
 #include <stdlib.h>
 #include "minishell.h"
-#include "ms_exec.h"
-#include "ms_tokenize.h"
-#include "ft_deque.h"
-#include "ft_hash.h"
-#include "ft_mem.h"
 
 int	main(void)
 {
 	t_params	params;
-	t_deque		*command;
-	char		*line;
+	t_result	result;
 
 	init_params(&params);
-	command = NULL;
-	while (true)
-	{
-		line = input_line();
-		if (!line)
-			break ;
-		command = tokenize(line);
-		ft_free(line);
-		if (execute_command(command, &params) == PROCESS_ERROR)
-			return (EXIT_FAILURE);
-		deque_clear_all(&command, free);
-	}
-	hs_clear(&params.env->hash);
-	ft_free(params.env);
-	rl_clear_history();
+	result = read_eval_print_loop(&params);
+	destroy(params);
+	if (result == PROCESS_ERROR)
+		return (EXIT_FAILURE);
 	return (params.status);
 }

--- a/srcs/repl.c
+++ b/srcs/repl.c
@@ -1,0 +1,29 @@
+#include <stdlib.h>
+#include "minishell.h"
+#include "ms_exec.h"
+#include "ms_tokenize.h"
+#include "ft_deque.h"
+#include "ft_mem.h"
+
+t_result	read_eval_print_loop(t_params *params)
+{
+	t_deque		*command;
+	t_result	result;
+	char		*line;
+
+	command = NULL;
+	result = SUCCESS;
+	while (true)
+	{
+		line = input_line();
+		if (!line)
+			break ;
+		command = tokenize(line);
+		ft_free(line);
+		result = execute_command(command, params);
+		deque_clear_all(&command, free);
+		if (result == PROCESS_ERROR)
+			break ;
+	}
+	return (result);
+}

--- a/srcs/repl.c
+++ b/srcs/repl.c
@@ -19,7 +19,7 @@ t_result	read_eval_print_loop(t_params *params)
 		if (!line)
 			break ;
 		command = tokenize(line);
-		ft_free(line);
+		ft_free(&line);
 		result = execute_command(command, params);
 		deque_clear_all(&command, free);
 		if (result == PROCESS_ERROR)


### PR DESCRIPTION
- [x] (minishell) fix: free -> ft_free
- [x] `execve("minishell", (char *[]){"minishell", NULL}, (char *[]){"", NULL});` などで呼ばれた時の `get_environ` の crash 対応 (key=value の形だけとは限らない)
  -> `declare_arg` が status を受け取らないように変更。`init_environ` から呼ばれた時は status 関係なく valid なら set するだけ、`ft_export` から呼ばれた時は呼び出し元で result を確認して status を set する、とすると key に空文字が来た場合は `is_valid_key` が false で弾いてくれる。
- [x] main() の status やっぱり params だけの方が…？相談。
  -> params だけにする
- [x] actions : norm の version を指定して走らせる。(intra は 3.3.51、最新は3.3.52)
  -> intra の方 3.3.51 に統一。

(branch name の数字ミスってます…)

-- review --
- [x] PROCESS_ERROR, SUCCESS, FAILURE, CONTINUE を e_num e_result にする
- [x] is_single_builtin の時に last_exit_status を設定できてないのを修正
- [x] ft_free をダブルポインタ―受け取りに修正
- [x] status と t_result をきちんと区別する