### PR TITLE
suggest: env_set_key_value

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ SRCS		+=	$(ENVIRONMENT)/clear.c \
 				$(ENVIRONMENT)/print_detail.c \
 				$(ENVIRONMENT)/print.c \
 				$(ENVIRONMENT)/set.c \
+				$(ENVIRONMENT)/set_dup_key_value.c \
 				$(ENVIRONMENT)/unset.c
 
 DEBUG_DIR	:=	debug

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -96,6 +96,10 @@ void		init_pwd(t_env *env);
 int			env_is_key_exist(t_env *env, const char *key);
 void		env_print_detail(t_env *env);
 void		env_print(t_env *env);
+void		env_set_dup_key_value(t_env *env, \
+									const char *key, \
+									const char *value, \
+									t_env_op op);
 void		env_set(t_env *env, char *key, char *value, t_env_op op);
 void		env_unset(t_env *env, const char *key);
 

--- a/srcs/builtin/ft_cd.c
+++ b/srcs/builtin/ft_cd.c
@@ -15,6 +15,7 @@ static bool	is_valid_cd_path(char *path, int *tmp_err)
 	return (true);
 }
 
+// todo: chdir, env->set pre-PWD+now-PWD? (., ..)
 static void	move_to_valid_path(char *path, t_context *context)
 {
 	(void)path;
@@ -47,23 +48,6 @@ static void	print_err_set_status(const char *arg, \
 				SHELL_NAME, CMD_CD, err_arg, err_msg);
 		*status = CD_ERROR_STATUS;
 	}
-}
-
-void	env_set_dup_key_value(t_env *env, \
-								const char *key, \
-								const char *value, \
-								t_env_op op)
-{
-	char	*dup_key;
-	char	*dup_value;
-
-	dup_key = ft_strdup(key);
-	if (!dup_key)
-		ft_abort();
-	dup_value = ft_strdup(value);
-	if (!dup_value)
-		ft_abort();
-	env->set(env, dup_key, dup_value, op);
 }
 
 static void	update_pwd(char *path, t_context *context)

--- a/srcs/builtin/ft_cd.c
+++ b/srcs/builtin/ft_cd.c
@@ -53,15 +53,19 @@ static void	print_err_set_status(const char *arg, \
 static void	update_pwd(char *path, t_context *context)
 {
 	t_env	*env;
+	char	*pwd_value;
+	char	*old_pwd_value;
 
 	ft_free(&context->internal_old_pwd);
 	context->internal_old_pwd = context->internal_pwd;
 	context->internal_pwd = path;
 	env = context->env;
+	pwd_value = context->internal_pwd;
+	old_pwd_value = context->internal_old_pwd;
 	if (env->is_key_exist(env, KEY_PWD))
-		env_set_dup_key_value(env, KEY_PWD, context->internal_pwd, ENV_ADD);
+		env_set_dup_key_value(env, KEY_PWD, pwd_value, ENV_ADD);
 	if (env->is_key_exist(env, KEY_OLDPWD))
-		env_set_dup_key_value(env, KEY_OLDPWD, context->internal_old_pwd, ENV_ADD);
+		env_set_dup_key_value(env, KEY_OLDPWD, old_pwd_value, ENV_ADD);
 }
 
 // arg

--- a/srcs/environment/declare_arg.c
+++ b/srcs/environment/declare_arg.c
@@ -79,6 +79,8 @@ t_result	env_declare_arg(const char *const arg, t_env *env)
 	result = separate_env_variables(arg, &key, &value, &op);
 	if (result == FAILURE || result == CONTINUE)
 		return (result);
-	env->set(env, key, value, op);
+	env_set_dup_key_value(env, key, value, op);
+	ft_free(&key);
+	ft_free(&value);
 	return (result);
 }

--- a/srcs/environment/init_old_pwd.c
+++ b/srcs/environment/init_old_pwd.c
@@ -2,7 +2,6 @@
 #include "minishell.h"
 #include "ms_builtin.h"
 #include "ft_mem.h"
-#include "ft_string.h"
 
 static bool	is_permission_denied(int tmp_err)
 {
@@ -38,12 +37,7 @@ static void	validate_and_delete_old_pwd(t_env *env)
 // value=NULL
 static void	set_only_old_pwd_key(t_env *env)
 {
-	char	*dup_key;
-
-	dup_key = ft_strdup(KEY_OLDPWD);
-	if (!dup_key)
-		ft_abort();
-	env->set(env, dup_key, NULL, ENV_ADD);
+	env_set_dup_key_value(env, KEY_OLDPWD, NULL, ENV_ADD);
 }
 
 void	init_old_pwd(t_env *env)

--- a/srcs/environment/init_pwd.c
+++ b/srcs/environment/init_pwd.c
@@ -1,22 +1,17 @@
 #include "minishell.h"
 #include "ms_builtin.h"
-#include "ft_string.h"
+#include "ft_mem.h"
 
 void	init_pwd(t_env *env)
 {
 	char	*pwd_path;
-	char	*dup_key;
 
 	pwd_path = get_working_directory(SHELL_INIT);
 	if (pwd_path == NULL)
 		env->unset(env, KEY_PWD);
 	else
 	{
-		dup_key = ft_strdup(KEY_PWD);
-		if (!dup_key)
-			ft_abort();
-		if (!pwd_path)
-			ft_abort();
-		env->set(env, dup_key, pwd_path, ENV_ADD);
+		env_set_dup_key_value(env, KEY_PWD, pwd_path, ENV_ADD);
+		ft_free(&pwd_path);
 	}
 }

--- a/srcs/environment/set_dup_key_value.c
+++ b/srcs/environment/set_dup_key_value.c
@@ -1,0 +1,28 @@
+#include "minishell.h"
+#include "ft_string.h"
+#include "ft_mem.h"
+
+void	env_set_dup_key_value(t_env *env, \
+								const char *key, \
+								const char *value, \
+								t_env_op op)
+{
+	char	*dup_key;
+	char	*dup_value;
+
+	dup_key = NULL;
+	if (key)
+	{
+		dup_key = ft_strdup(key);
+		if (!dup_key)
+			ft_abort();
+	}
+	dup_value = NULL;
+	if (value)
+	{
+		dup_value = ft_strdup(value);
+		if (!dup_value)
+			ft_abort();
+	}
+	env->set(env, dup_key, dup_value, op);
+}

--- a/srcs/environment/set_dup_key_value.c
+++ b/srcs/environment/set_dup_key_value.c
@@ -2,6 +2,7 @@
 #include "ft_string.h"
 #include "ft_mem.h"
 
+// key : valid key
 void	env_set_dup_key_value(t_env *env, \
 								const char *key, \
 								const char *value, \
@@ -10,13 +11,9 @@ void	env_set_dup_key_value(t_env *env, \
 	char	*dup_key;
 	char	*dup_value;
 
-	dup_key = NULL;
-	if (key)
-	{
-		dup_key = ft_strdup(key);
-		if (!dup_key)
-			ft_abort();
-	}
+	dup_key = ft_strdup(key);
+	if (!dup_key)
+		ft_abort();
 	dup_value = NULL;
 	if (value)
 	{


### PR DESCRIPTION
`ft_cd` #175 への 提案 branch
- `env_set_dup_key_value()` が中で必ず malloc して `env->set()` するように決めた方が使いやすいかも…？
  - `init_pwd()` の中でこれを使う
  - `init_old_pwd()` の中でこれを使う
  - `declare_arg()` の中でこれを使う -> 両方新しく作って free みたいになってるけどこっちの方が良いのかどうなのか相談したい。確保した人が free する、という方が良いとするとこれが正しい気もしてくる…

leak なし、norm は error.