### PR TITLE
update cd canonicalize

### DIFF
--- a/includes/ms_builtin.h
+++ b/includes/ms_builtin.h
@@ -27,6 +27,8 @@
 # define ABSOLUTE_PATH_HEAD	'/'
 # define PATH_DELIMITER_CHR	'/'
 # define PATH_DELIMITER_STR	"/"
+# define PATH_DOT			"."
+# define PATH_DOT_DOT		".."
 
 # define VAR_PRINT_QUOTE	"\""
 

--- a/srcs/builtin/ft_cd_canonicalize.c
+++ b/srcs/builtin/ft_cd_canonicalize.c
@@ -104,6 +104,56 @@ static void	del(void *content)
 	ft_free(&content);
 }
 
+static void	erase_dot_path(t_deque **dq)
+{
+	t_deque			*stack;
+	t_deque_node	*pop_node;
+	char			*path_elem;
+
+	stack = deque_new();
+	if (!stack)
+		ft_abort();
+	while (!deque_is_empty(*dq))
+	{
+		pop_node = deque_pop_front(*dq);
+		path_elem = (char *)pop_node->content;
+		if (ft_streq(path_elem, PATH_DOT))
+		{
+			deque_clear_node(&pop_node, del);
+			continue ;
+		}
+		deque_add_back(stack, pop_node);
+	}
+	deque_clear_all(dq, del);
+	*dq = stack;
+}
+
+static void	erase_dot_dot_path(t_deque **dq)
+{
+	t_deque			*stack;
+	t_deque_node	*pop_node;
+	char			*path_elem;
+
+	stack = deque_new();
+	if (!stack)
+		ft_abort();
+	while (!deque_is_empty(*dq))
+	{
+		pop_node = deque_pop_front(*dq);
+		path_elem = (char *)pop_node->content;
+		if (ft_streq(path_elem, PATH_DOT_DOT))
+		{
+			deque_clear_node(&pop_node, del);
+			pop_node = deque_pop_back(stack);
+			deque_clear_node(&pop_node, del);
+			continue ;
+		}
+		deque_add_back(stack, pop_node);
+	}
+	deque_clear_all(dq, del);
+	*dq = stack;
+}
+
 // 	 PWD         path
 // "/home/aaa"  libft/            -> /home/aaa/libft
 //              ./libft/          -> /home/aaa/libft
@@ -120,8 +170,8 @@ char	*cd_canonicalize_path(const char *path, t_context *context)
 	char	*absolute_path;
 
 	path_elems = separate_path_and_join(path, context);
-	// erase .
-	// erase path/../
+	erase_dot_path(&path_elems);
+	erase_dot_dot_path(&path_elems);
 	absolute_path = convert_path_elems_to_absolute_path(path_elems);
 	deque_clear_all(&path_elems, del);
 	return (absolute_path);

--- a/srcs/builtin/ft_cd_canonicalize.c
+++ b/srcs/builtin/ft_cd_canonicalize.c
@@ -154,6 +154,28 @@ static void	erase_dot_dot_path(t_deque **dq)
 	*dq = stack;
 }
 
+static bool	is_head_double_slash(const char *path)
+{
+	return (path[0] == PATH_DELIMITER_CHR \
+			&& path[1] == PATH_DELIMITER_CHR \
+			&& path[2] != PATH_DELIMITER_CHR);
+}
+
+static char	*handle_double_slash_path(const char *path, char *absolute_path)
+{
+	char	*new_path;
+
+	if (is_head_double_slash(path))
+	{
+		new_path = ft_strjoin(PATH_DELIMITER_STR, absolute_path);
+		if (!new_path)
+			ft_abort();
+		ft_free(&absolute_path);
+		return (new_path);
+	}
+	return (absolute_path);
+}
+
 // 	 PWD         path
 // "/home/aaa"  libft/            -> /home/aaa/libft
 //              ./libft/          -> /home/aaa/libft
@@ -173,6 +195,7 @@ char	*cd_canonicalize_path(const char *path, t_context *context)
 	erase_dot_path(&path_elems);
 	erase_dot_dot_path(&path_elems);
 	absolute_path = convert_path_elems_to_absolute_path(path_elems);
+	absolute_path = handle_double_slash_path(path, absolute_path);
 	deque_clear_all(&path_elems, del);
 	return (absolute_path);
 }


### PR DESCRIPTION
#190 ft_cd のパスの正規化部分の実装

- [x] absolute path を作る際の `.` と `..`(とその親) を削除
  - stack (内部は deque) を使って dot なら pop, dot-dot なら pop-pop!
- [x] `cd //`, `cd ///` ... などの slash 連続 path の対応