### PR TITLE
fix AST

### DIFF
--- a/includes/ms_parse.h
+++ b/includes/ms_parse.h
@@ -50,9 +50,12 @@ bool		is_parenthesis_concatenated_all(t_deque_node *node);
 bool		is_valid_redirect_syntax_all(t_deque_node *node);
 
 /* ast */
-t_ast		*create_operator_list_node(t_deque_node **token_node);
-t_ast		*create_command_list_node(t_deque_node **token_node);
-t_ast		*create_command_or_subshell_node(t_deque_node **token_node);
+t_ast		*create_operator_list_node(t_deque_node **token_node, \
+										t_context *context);
+t_ast		*create_command_list_node(t_deque_node **token_node, \
+										t_context *context);
+t_ast		*create_command_or_subshell_node(t_deque_node **token_node, \
+												t_context *context);
 
 t_ast		*new_command_leaf(void);
 t_ast		*new_ast_node(t_node_kind kind, t_ast *left, t_ast *right);

--- a/srcs/parse/abstruct_syntax_tree.c
+++ b/srcs/parse/abstruct_syntax_tree.c
@@ -34,8 +34,10 @@ t_ast	*create_operator_list_node(t_deque_node **token_node, \
 	left_node = create_command_list_node(token_node, context);
 	if (!left_node)
 		return (NULL);
-	while (*token_node && is_token_kind_and_or_from_node(*token_node) && context->status != SYNTAX_ERROR)
+	while (*token_node && is_token_kind_and_or_from_node(*token_node))
 	{
+		if (context->status != SYNTAX_ERROR)
+			break ;
 		kind = convert_kind_token_to_node(*token_node); // &&, ||
 		*token_node = (*token_node)->next;
 		right_node = create_command_list_node(token_node, context);
@@ -56,8 +58,10 @@ t_ast	*create_command_list_node(t_deque_node **token_node, t_context *context)
 	left_node = create_command_or_subshell_node(token_node, context);
 	if (!left_node)
 		return (NULL);
-	while (*token_node && is_token_kind_pipe_from_node(*token_node) && context->status != SYNTAX_ERROR)
+	while (*token_node && is_token_kind_pipe_from_node(*token_node))
 	{
+		if (context->status != SYNTAX_ERROR)
+			break ;
 		kind = convert_kind_token_to_node(*token_node); // |
 		*token_node = (*token_node)->next;
 		right_node = create_command_or_subshell_node(token_node, context);

--- a/srcs/parse/abstruct_syntax_tree.c
+++ b/srcs/parse/abstruct_syntax_tree.c
@@ -36,7 +36,7 @@ t_ast	*create_operator_list_node(t_deque_node **token_node, \
 		return (NULL);
 	while (*token_node && is_token_kind_and_or_from_node(*token_node))
 	{
-		if (context->status != SYNTAX_ERROR)
+		if (context->status == SYNTAX_ERROR)
 			break ;
 		kind = convert_kind_token_to_node(*token_node); // &&, ||
 		*token_node = (*token_node)->next;
@@ -60,7 +60,7 @@ t_ast	*create_command_list_node(t_deque_node **token_node, t_context *context)
 		return (NULL);
 	while (*token_node && is_token_kind_pipe_from_node(*token_node))
 	{
-		if (context->status != SYNTAX_ERROR)
+		if (context->status == SYNTAX_ERROR)
 			break ;
 		kind = convert_kind_token_to_node(*token_node); // |
 		*token_node = (*token_node)->next;
@@ -79,7 +79,8 @@ static t_ast	*create_command_leaf(t_deque_node **token_node)
 	return (ast_node);
 }
 
-static t_ast	*create_subshell_node(t_deque_node **token_node, t_context *context)
+static t_ast	*create_subshell_node(t_deque_node **token_node, \
+										t_context *context)
 {
 	t_ast	*ast_node;
 

--- a/srcs/parse/abstruct_syntax_tree.c
+++ b/srcs/parse/abstruct_syntax_tree.c
@@ -34,7 +34,7 @@ t_ast	*create_operator_list_node(t_deque_node **token_node, \
 	left_node = create_command_list_node(token_node, context);
 	if (!left_node)
 		return (NULL);
-	while (*token_node && is_token_kind_and_or_from_node(*token_node))
+	while (*token_node && is_token_kind_and_or_from_node(*token_node) && context->status != SYNTAX_ERROR)
 	{
 		kind = convert_kind_token_to_node(*token_node); // &&, ||
 		*token_node = (*token_node)->next;
@@ -56,7 +56,7 @@ t_ast	*create_command_list_node(t_deque_node **token_node, t_context *context)
 	left_node = create_command_or_subshell_node(token_node, context);
 	if (!left_node)
 		return (NULL);
-	while (*token_node && is_token_kind_pipe_from_node(*token_node))
+	while (*token_node && is_token_kind_pipe_from_node(*token_node) && context->status != SYNTAX_ERROR)
 	{
 		kind = convert_kind_token_to_node(*token_node); // |
 		*token_node = (*token_node)->next;
@@ -107,11 +107,16 @@ t_ast	*create_command_or_subshell_node(t_deque_node **token_node, \
 	t_ast	*ast_node;
 
 	if (!*token_node)
-		return (ast_print_error(*token_node));
+	{
+		context->status = SYNTAX_ERROR;
+		return (NULL);
+	}
 	ast_node = NULL;
 	if (is_token_kind_command_as_ast_node(*token_node))
 		ast_node = create_command_leaf(token_node);
 	else if (is_token_kind_subshell_as_ast_node(*token_node))
 		ast_node = create_subshell_node(token_node, context);
+	if (!ast_node)
+		context->status = SYNTAX_ERROR;
 	return (ast_node);
 }

--- a/srcs/parse/abstruct_syntax_tree.c
+++ b/srcs/parse/abstruct_syntax_tree.c
@@ -1,3 +1,4 @@
+#include "minishell.h"
 #include "ms_parse.h"
 #include "ms_tokenize.h"
 #include "ft_deque.h"
@@ -23,20 +24,21 @@ arithmetic
 // expr	= <com_list> '&&' <com_list>
 //		| <com_list> '||' <com_list>
 //		| <com_list>
-t_ast	*create_operator_list_node(t_deque_node **token_node)
+t_ast	*create_operator_list_node(t_deque_node **token_node, \
+									t_context *context)
 {
 	t_ast		*left_node;
 	t_ast		*right_node;
 	t_node_kind	kind;
 
-	left_node = create_command_list_node(token_node);
+	left_node = create_command_list_node(token_node, context);
 	if (!left_node)
 		return (NULL);
 	while (*token_node && is_token_kind_and_or_from_node(*token_node))
 	{
 		kind = convert_kind_token_to_node(*token_node); // &&, ||
 		*token_node = (*token_node)->next;
-		right_node = create_command_list_node(token_node);
+		right_node = create_command_list_node(token_node, context);
 		left_node = new_ast_node(kind, left_node, right_node);
 	}
 	return (left_node);
@@ -45,20 +47,20 @@ t_ast	*create_operator_list_node(t_deque_node **token_node)
 // <com_list>
 // term	= <com> '|' <com>
 // 		| <com>
-t_ast	*create_command_list_node(t_deque_node **token_node)
+t_ast	*create_command_list_node(t_deque_node **token_node, t_context *context)
 {
 	t_ast		*left_node;
 	t_ast		*right_node;
 	t_node_kind	kind;
 
-	left_node = create_command_or_subshell_node(token_node);
+	left_node = create_command_or_subshell_node(token_node, context);
 	if (!left_node)
 		return (NULL);
 	while (*token_node && is_token_kind_pipe_from_node(*token_node))
 	{
 		kind = convert_kind_token_to_node(*token_node); // |
 		*token_node = (*token_node)->next;
-		right_node = create_command_or_subshell_node(token_node);
+		right_node = create_command_or_subshell_node(token_node, context);
 		left_node = new_ast_node(kind, left_node, right_node);
 	}
 	return (left_node);
@@ -73,7 +75,7 @@ static t_ast	*create_command_leaf(t_deque_node **token_node)
 	return (ast_node);
 }
 
-static t_ast	*create_subshell_node(t_deque_node **token_node)
+static t_ast	*create_subshell_node(t_deque_node **token_node, t_context *context)
 {
 	t_ast	*ast_node;
 
@@ -82,7 +84,7 @@ static t_ast	*create_subshell_node(t_deque_node **token_node)
 		*token_node = (*token_node)->next;
 		if (is_token_kind_paren_right_as_ast_node(*token_node))
 			return (NULL);
-		ast_node = create_operator_list_node(token_node);
+		ast_node = create_operator_list_node(token_node, context);
 	}
 	if (is_token_kind_paren_right_as_ast_node(*token_node))
 	{
@@ -99,7 +101,8 @@ static t_ast	*create_subshell_node(t_deque_node **token_node)
 // <com or subshell>
 // prim	= <com>
 // 		| '(' expr ')'
-t_ast	*create_command_or_subshell_node(t_deque_node **token_node)
+t_ast	*create_command_or_subshell_node(t_deque_node **token_node, \
+											t_context *context)
 {
 	t_ast	*ast_node;
 
@@ -109,6 +112,6 @@ t_ast	*create_command_or_subshell_node(t_deque_node **token_node)
 	if (is_token_kind_command_as_ast_node(*token_node))
 		ast_node = create_command_leaf(token_node);
 	else if (is_token_kind_subshell_as_ast_node(*token_node))
-		ast_node = create_subshell_node(token_node);
+		ast_node = create_subshell_node(token_node, context);
 	return (ast_node);
 }

--- a/srcs/parse/parse.c
+++ b/srcs/parse/parse.c
@@ -21,10 +21,17 @@ static bool	is_valid_pre_parse_syntax(t_deque_node *node)
 	return (true);
 }
 
-static void	*destroy_tokens_and_ast(t_deque **tokens, t_ast **ast)
+// todo: tmp destroy func
+static void	*destroy_tokens_and_ast(t_deque **tokens, \
+									t_ast **ast, \
+									bool is_print_error, \
+									t_deque_node *head_node)
 {
+	// debug_print_ast_tree(*ast, __func__);
 	if (ast)
 		destroy_ast_tree(ast);
+	if (is_print_error)
+		ast_print_error(head_node);
 	destroy_tokens(tokens, del_token);
 	return (NULL);
 }
@@ -42,20 +49,17 @@ t_ast	*parse(t_deque **tokens, t_context *context)
 	if (!is_valid_pre_parse_syntax(head_node))
 	{
 		context->status = SYNTAX_ERROR; // todo: print syntax error
-		return (destroy_tokens_and_ast(tokens, NULL));
+		return (destroy_tokens_and_ast(tokens, NULL, false, head_node));
 	}
 	ast = create_operator_list_node(&head_node, context);
 	if (head_node)
 		context->status = SYNTAX_ERROR;
 	if (context->status == SYNTAX_ERROR)
-	{
-		ast_print_error(head_node);
-		return (destroy_tokens_and_ast(tokens, &ast));
-	}
+		return (destroy_tokens_and_ast(tokens, &ast, true, head_node));
 	heredoc_result = execute_heredoc(ast);
 	if (heredoc_result == PROCESS_ERROR)
-		return (destroy_tokens_and_ast(tokens, &ast));
-	debug_print_ast_tree(ast, __func__);
+		return (destroy_tokens_and_ast(tokens, &ast, false, head_node));
+	// debug_print_ast_tree(ast, __func__);
 	// destroy_tokens(tokens, del_token); when exec by ast, destroy tokens.
 	return (ast);
 }

--- a/srcs/parse/parse.c
+++ b/srcs/parse/parse.c
@@ -46,15 +46,16 @@ t_ast	*parse(t_deque **tokens, t_context *context)
 	}
 	ast = create_operator_list_node(&head_node, context);
 	if (head_node)
+		context->status = SYNTAX_ERROR;
+	if (context->status == SYNTAX_ERROR)
 	{
-		context->status = SYNTAX_ERROR; // todo: print syntax error
 		ast_print_error(head_node);
 		return (destroy_tokens_and_ast(tokens, &ast));
 	}
 	heredoc_result = execute_heredoc(ast);
 	if (heredoc_result == PROCESS_ERROR)
 		return (destroy_tokens_and_ast(tokens, &ast));
-	// debug_print_ast_tree(ast, __func__);
+	debug_print_ast_tree(ast, __func__);
 	// destroy_tokens(tokens, del_token); when exec by ast, destroy tokens.
 	return (ast);
 }

--- a/srcs/parse/parse.c
+++ b/srcs/parse/parse.c
@@ -44,7 +44,7 @@ t_ast	*parse(t_deque **tokens, t_context *context)
 		context->status = SYNTAX_ERROR; // todo: print syntax error
 		return (destroy_tokens_and_ast(tokens, NULL));
 	}
-	ast = create_operator_list_node(&head_node);
+	ast = create_operator_list_node(&head_node, context);
 	if (head_node)
 	{
 		context->status = SYNTAX_ERROR; // todo: print syntax error


### PR DESCRIPTION
- [x] これがエラーにできてなかったので op の right node が op でないかどうかの check を追加
-> context を渡して葉の方で SYNTAX_ERROR を設定し、以降は SYNTAX_ERROR を check して伝搬することで対応
```shell
minishell echo a && && echo b
-------------------------
parse       
└─[&&]
   ├─[&&]
   |  └─echo a  : 
   └─echo b  : 
-------------------------
```
- [x] ~~error にできてない2~~ -> できてた
```shell
( a ) ( )
( a ) b
```

- [x] ~~error にできてない3~~ -> できてた
```shell
a ( )
a ( a )
```


~~小手先の修正な気がしていて、redirect も入ってくるし `||, &&`  node 専用関数みたいに `( )` node 専用関数が必要な気がしてきました…？(まだ作ってないですが)
方針が合ってそうかの確認したいです。~~
仮なので norm error はあり