### PR TITLE
implement exec subshell

### DIFF
--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -5,6 +5,8 @@
 # include <stddef.h>
 # include <stdint.h>
 # include "ms_result.h"
+// todo: erase
+#include "ft_dprintf.h"
 
 /* return value */
 # define ACCESS_ERROR	(-1)

--- a/includes/ms_exec.h
+++ b/includes/ms_exec.h
@@ -64,4 +64,9 @@ bool			is_single_builtin_command(t_ast *self_node);
 bool			is_last_command_node(t_ast *self_node);
 char			*get_head_token_str(t_deque *command);
 
+t_result		get_last_command_status(pid_t pid, \
+										int *wait_status, \
+										uint8_t *last_status);
+t_result		wait_all_child_process(int wait_status);
+
 #endif //MS_EXEC_H

--- a/includes/ms_parse.h
+++ b/includes/ms_parse.h
@@ -76,6 +76,7 @@ char		*create_heredoc_filename(void);
 t_result	open_heredoc_filedes(int *in_fd, char **filename);
 
 /* is */
+bool		is_node_kind_subshell(t_node_kind node_kind);
 bool		is_node_kind_exec_heredoc(t_node_kind node_kind);
 bool		is_node_kind_and_or(t_node_kind node_kind);
 

--- a/srcs/debug/debug_print_ast.c
+++ b/srcs/debug/debug_print_ast.c
@@ -1,4 +1,5 @@
 #include "minishell.h"
+#include "ms_exec.h"
 #include "ms_parse.h"
 #include "ms_tokenize.h"
 #include "ft_deque.h"
@@ -24,13 +25,15 @@ static void	print_tokens_dq_in_oneline(t_deque *dq)
 
 static void	print_token_comamnd_and_redirect(t_ast *ast)
 {
-	print_tokens_dq_in_oneline(ast->command);
+	if (ast->command)
+		print_tokens_dq_in_oneline(ast->command);
 	if (ast->redirects)
 	{
-		ft_dprintf(STDERR_FILENO, " : ");
+		ft_dprintf(STDERR_FILENO, ":");
 		print_tokens_dq_in_oneline(ast->redirects->list);
-		ft_dprintf(STDERR_FILENO, " : %d", ast->prev_fd);
 	}
+	ft_dprintf(STDERR_FILENO, " :prev[%d]in[%d]out[%d] ", \
+				ast->prev_fd, ast->pipe_fd[READ], ast->pipe_fd[WRITE]);
 	ft_dprintf(STDERR_FILENO, "\n");
 }
 
@@ -58,6 +61,11 @@ static void	print_tree_node(t_ast *node, int depth, int is_rhs, char *prefix)
 	else if (node->kind == NODE_KIND_SUBSHELL)
 	{
 		ft_dprintf(STDERR_FILENO, "( ) ");
+		print_token_comamnd_and_redirect(node);
+	}
+	else if (node->kind == NODE_KIND_OP_PIPE)
+	{
+		ft_dprintf(STDERR_FILENO, "[|] ");
 		print_token_comamnd_and_redirect(node);
 	}
 	else

--- a/srcs/debug/debug_print_ast.c
+++ b/srcs/debug/debug_print_ast.c
@@ -29,6 +29,7 @@ static void	print_token_comamnd_and_redirect(t_ast *ast)
 	{
 		ft_dprintf(STDERR_FILENO, " : ");
 		print_tokens_dq_in_oneline(ast->redirects->list);
+		ft_dprintf(STDERR_FILENO, " : %d", ast->prev_fd);
 	}
 	ft_dprintf(STDERR_FILENO, "\n");
 }

--- a/srcs/exec/child_pipes.c
+++ b/srcs/exec/child_pipes.c
@@ -39,12 +39,13 @@ t_result	handle_child_pipes(t_ast *self_node)
 
 	if (!is_first_command(prev_fd))
 	{
-		// ft_dprintf(2, "-- first command ------\n");
+		ft_dprintf(2, "-- not first command ------\n");
 		if (handle_child_pipes_except_first(prev_fd) == PROCESS_ERROR)
 			return (PROCESS_ERROR);
 	}
 	if (!is_last_command_node(self_node))
 	{
+		ft_dprintf(2, "-- not last command ------\n");
 		if (handle_child_pipes_except_last(self_node->pipe_fd) == PROCESS_ERROR)
 			return (PROCESS_ERROR);
 	}

--- a/srcs/exec/child_pipes.c
+++ b/srcs/exec/child_pipes.c
@@ -16,6 +16,7 @@ static t_result	handle_child_pipes_except_first(int prev_fd)
 
 static t_result	handle_child_pipes_except_last(int pipe_fd[2])
 {
+	ft_dprintf(2, "----------------------\n");
 	if (x_close(pipe_fd[READ]) == CLOSE_ERROR)
 		return (PROCESS_ERROR);
 	if (x_close(STDOUT_FILENO) == CLOSE_ERROR)
@@ -38,6 +39,7 @@ t_result	handle_child_pipes(t_ast *self_node)
 
 	if (!is_first_command(prev_fd))
 	{
+		// ft_dprintf(2, "-- first command ------\n");
 		if (handle_child_pipes_except_first(prev_fd) == PROCESS_ERROR)
 			return (PROCESS_ERROR);
 	}
@@ -46,5 +48,11 @@ t_result	handle_child_pipes(t_ast *self_node)
 		if (handle_child_pipes_except_last(self_node->pipe_fd) == PROCESS_ERROR)
 			return (PROCESS_ERROR);
 	}
+	// char c;
+	// while (read(self_node->pipe_fd[WRITE], &c, 1) > 0)
+	// {
+	// 	write(2, &c, 1);
+	// }
+	// ft_dprintf(2, "[%s/%d]\n", get_head_token_str(self_node->command), self_node->prev_fd);
 	return (SUCCESS);
 }

--- a/srcs/exec/exec_command.c
+++ b/srcs/exec/exec_command.c
@@ -25,6 +25,8 @@ bool	is_last_command_node(t_ast *self_node)
 	t_ast	*parent_node;
 
 	parent_node = self_node->parent;
+	if (self_node->kind == NODE_KIND_SUBSHELL)
+		return (true);
 	if (self_node->kind != NODE_KIND_COMMAND)
 		return (false);
 	if (!parent_node)

--- a/srcs/exec/exec_command.c
+++ b/srcs/exec/exec_command.c
@@ -24,17 +24,23 @@ bool	is_last_command_node(t_ast *self_node)
 {
 	t_ast	*parent_node;
 
+	// ft_dprintf(2, "============ %s : %d =================\n", get_head_token_str(self_node->command), self_node->kind);
 	parent_node = self_node->parent;
-	if (self_node->kind == NODE_KIND_SUBSHELL)
-		return (true);
-	if (self_node->kind != NODE_KIND_COMMAND)
-		return (false);
+	// if (self_node->kind == NODE_KIND_SUBSHELL)
+	// 	return (true);
+	// if (self_node->kind != NODE_KIND_COMMAND)
+	// 	return (false);
 	if (!parent_node)
 		return (true);
-	if (!is_last_pipe_node(parent_node))
-		return (false);
-	if (parent_node->right == self_node)
+	if (is_last_pipe_node(parent_node) && parent_node->right == self_node)
+	{
+		ft_dprintf(2, "cat?????\n");
 		return (true);
+	}
+	if (is_node_kind_and_or(parent_node->kind))
+		return (true);
+	if (parent_node->kind == NODE_KIND_SUBSHELL)
+		return (is_last_command_node(parent_node));
 	return (false);
 }
 

--- a/srcs/exec/exec_command.c
+++ b/srcs/exec/exec_command.c
@@ -51,9 +51,12 @@ t_result	exec_command_each(t_ast *self_node, t_context *context)
 
 	if (self_node->kind != NODE_KIND_COMMAND)
 		return (SUCCESS);
-
-	if (x_pipe(self_node->pipe_fd) == PIPE_ERROR)
-		return (PROCESS_ERROR);
+	// no need new pipe, when parent is subshell node (ittan ignore builtin..)
+	if (self_node->parent && self_node->parent->kind == NODE_KIND_OP_PIPE)
+	{
+		if (x_pipe(self_node->pipe_fd) == PIPE_ERROR)
+			return (PROCESS_ERROR);
+	}
 	self_node->pid = x_fork();
 	if (self_node->pid == FORK_ERROR)
 		return (PROCESS_ERROR);

--- a/srcs/exec/parent_pipes.c
+++ b/srcs/exec/parent_pipes.c
@@ -21,6 +21,7 @@ static t_result	handle_parent_pipes_except_last(t_ast *self_node)
 	}
 	if (x_close(self_node->pipe_fd[WRITE]) == CLOSE_ERROR)
 		return (PROCESS_ERROR);
+	// debug_print_ast_tree(self_node, __func__);
 	return (SUCCESS);
 }
 
@@ -30,14 +31,17 @@ t_result	handle_parent_pipes(t_ast *self_node)
 
 	if (!is_first_command(prev_fd))
 	{
+		// ft_dprintf(2, "-- p not first command ------\n");
 		if (handle_parent_pipes_except_first(prev_fd) == PROCESS_ERROR)
 			return (PROCESS_ERROR);
 	}
 	if (!is_last_command_node(self_node))
 	{
+		// ft_dprintf(2, "-- p not last command ------\n");
 		if (handle_parent_pipes_except_last(self_node) == PROCESS_ERROR)
 			return (PROCESS_ERROR);
 	}
 	// ft_dprintf(2, "3 pipe_fd : %d, %d\n", self_node->pipe_fd[0], self_node->pipe_fd[1]);
+	// debug_print_ast_tree(self_node, __func__);
 	return (SUCCESS);
 }

--- a/srcs/exec/parent_pipes.c
+++ b/srcs/exec/parent_pipes.c
@@ -14,7 +14,11 @@ static t_result	handle_parent_pipes_except_first(int prev_fd)
 static t_result	handle_parent_pipes_except_last(t_ast *self_node)
 {
 	if (self_node->parent)
+	{
+		// ft_dprintf(2, "1 prev_fd : %d\n", self_node->parent->prev_fd);
 		self_node->parent->prev_fd = self_node->pipe_fd[READ]; // parent_prev
+		// ft_dprintf(2, "2 prev_fd : %d\n", self_node->parent->prev_fd);
+	}
 	if (x_close(self_node->pipe_fd[WRITE]) == CLOSE_ERROR)
 		return (PROCESS_ERROR);
 	return (SUCCESS);
@@ -34,5 +38,6 @@ t_result	handle_parent_pipes(t_ast *self_node)
 		if (handle_parent_pipes_except_last(self_node) == PROCESS_ERROR)
 			return (PROCESS_ERROR);
 	}
+	// ft_dprintf(2, "3 pipe_fd : %d, %d\n", self_node->pipe_fd[0], self_node->pipe_fd[1]);
 	return (SUCCESS);
 }

--- a/srcs/exec/parent_process.c
+++ b/srcs/exec/parent_process.c
@@ -5,7 +5,7 @@
 #include "ms_parse.h"
 #include "ft_sys.h"
 
-static t_result	get_last_command_status(pid_t pid, \
+t_result	get_last_command_status(pid_t pid, \
 									int *wait_status, \
 									uint8_t *last_status)
 {
@@ -20,7 +20,7 @@ static t_result	get_last_command_status(pid_t pid, \
 }
 
 // if wait error, no need for auto perror.
-static t_result	wait_all_child_process(int wait_status)
+t_result	wait_all_child_process(int wait_status)
 {
 	while (true)
 	{

--- a/srcs/parse/is_node_kind.c
+++ b/srcs/parse/is_node_kind.c
@@ -5,7 +5,7 @@ static bool	is_node_kind_command(t_node_kind node_kind)
 	return (node_kind == NODE_KIND_COMMAND);
 }
 
-static bool	is_node_kind_subshell(t_node_kind node_kind)
+bool	is_node_kind_subshell(t_node_kind node_kind)
 {
 	return (node_kind == NODE_KIND_SUBSHELL);
 }


### PR DESCRIPTION
7/8 これはできる
`/bin/ls | /bin/cat`
`( /bin/ls )`
`( ( /bin/ls ) )`

7/9 お試し
subshell
子プロセスに入る前に pipefd を同期して、
親が `|` node の時のみ `pipe()` を新規で作るようにしてみた。(cd とかは一旦考えず…)
これにより親で作成した pipefd を使って流せるようにはなってそう…一旦。

この cat が出力されるようになったが wait か close とかに失敗してるっぽくて終了しない
`( /bin/ls ) | /bin/cat`
これはできる
`/bin/ls | ( /bin/grep l )`
2 重 + `|` とかもまだ。根本から考える必要がありそう…？
`( ( /bin/ls ) ) | /bin/grep a`

#211 で解決していたーので閉じ。