### PR TITLE
add is_quoted_arr in token struct

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,6 +144,7 @@ SRCS		+=	$(TOKEN_DIR)/del_token.c \
 				$(TOKEN_DIR)/is_token_kind_from_node_subshell.c \
 				$(TOKEN_DIR)/is_token_str.c \
 				$(TOKEN_DIR)/remove_quote.c \
+				$(TOKEN_DIR)/set_is_quoted_arr.c \
 				$(TOKEN_DIR)/set_token_kind.c \
 				$(TOKEN_DIR)/set_token_quote_all.c \
 				$(TOKEN_DIR)/tokenize.c \

--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,7 @@ DEBUG_DIR	:=	debug
 SRCS		+=	$(DEBUG_DIR)/debug_print_ast.c \
 				$(DEBUG_DIR)/debug_print_ast_sub.c \
 				$(DEBUG_DIR)/debug_token_dq.c \
+				$(DEBUG_DIR)/debug_token_dq_sub.c \
 				$(DEBUG_DIR)/put.c
 
 EXEC_DIR	:=	exec

--- a/includes/ms_expansion.h
+++ b/includes/ms_expansion.h
@@ -21,7 +21,9 @@ char		*substr_before_dollar(char **str);
 void		remove_empty_tokens(t_deque *tokens);
 void		concat_tokens(t_deque *tokens);
 void		split_expand_word(t_deque **tokens);
-void		word_split_and_add(char *token_str, t_deque *expanded);
+void		word_split_and_add(char *token_str, \
+								t_deque *expanded, \
+								bool concat_next);
 void		expand_wildcard(t_deque **tokens);
 t_deque		*get_pattern_matched_filenames(const char *token_str);
 bool		is_pattern_match_target_path(const char *match_str, \

--- a/includes/ms_tokenize.h
+++ b/includes/ms_tokenize.h
@@ -45,11 +45,11 @@ typedef enum e_token_kind {
 	TOKEN_KIND_PAREN_RIGHT,
 }	t_token_kind;
 
-//todo: content of concat_next
 typedef struct s_token {
 	char			*str;
 	t_token_kind	kind;
 	t_quote			quote;
+	bool			*is_quoted_arr; // len of is_quoted same as len(str)
 	bool			concat_next;
 }	t_token;
 

--- a/includes/ms_tokenize.h
+++ b/includes/ms_tokenize.h
@@ -86,6 +86,8 @@ bool			is_token_kind_subshell_as_ast_node(t_deque_node *token_node);
 void			set_token_kinds_all(t_deque *tokens);
 void			set_token_quote_type_all(t_deque *tokens);
 void			remove_quote_in_token_str(t_deque *tokens);
+void			set_is_quoted_arr(t_deque *tokens);
+void			set_is_quoted_value_to_arr(t_token *token);
 
 /* validate */
 bool			is_closed_quote_all(t_deque_node *node);

--- a/includes/ms_tokenize.h
+++ b/includes/ms_tokenize.h
@@ -102,5 +102,6 @@ void			*destroy_tokens(t_deque **command, void (*del)(void *));
 
 /* debug */
 char			*get_token_kind_str(t_token_kind kind); //tmp, enum
+char			*get_quote_str(t_quote quote);
 
 #endif //MS_TOKENIZE_H

--- a/srcs/debug/debug_token_dq.c
+++ b/srcs/debug/debug_token_dq.c
@@ -12,47 +12,25 @@
 //}	t_token;
 //
 
-char	*get_token_kind_str(t_token_kind kind)
-{
-	if (kind == TOKEN_KIND_WORD)
-		return ("w");
-	if (kind == TOKEN_KIND_OP_PIPE)
-		return ("|");
-	if (kind == TOKEN_KIND_OP_OR)
-		return ("||");
-	if (kind == TOKEN_KIND_OP_AND)
-		return ("&&");
-	if (kind == TOKEN_KIND_REDIRECT_IN)
-		return ("<");
-	if (kind == TOKEN_KIND_REDIRECT_HEREDOC)
-		return ("<<");
-	if (kind == TOKEN_KIND_REDIRECT_OUT)
-		return (">");
-	if (kind == TOKEN_KIND_REDIRECT_APPEND)
-		return (">>");
-	if (kind == TOKEN_KIND_PAREN_LEFT)
-		return ("(");
-	if (kind == TOKEN_KIND_PAREN_RIGHT)
-		return (")");
-	return ("Error");
-}
-
-static char	*get_quote_str(t_quote quote)
-{
-	if (quote == QUOTE_SINGLE)
-		return ("\'");
-	if (quote == QUOTE_DOUBLE)
-		return ("\"");
-	if (quote == QUOTE_NONE)
-		return ("");
-	return ("Error");
-}
-
 static char	*get_concat_str(bool is_concat_next)
 {
 	if (is_concat_next)
 		return ("=");
 	return ("");
+}
+
+static void	print_is_quoted_arr(t_token *token)
+{
+	size_t	i;
+
+	ft_dprintf(2, "  is_quoted:[");
+	i = 0;
+	while (token->str && token->str[i])
+	{
+		ft_dprintf(2, "%d", token->is_quoted_arr[i]);
+		i++;
+	}
+	ft_dprintf(2, "]\n");
 }
 
 void	debug_token_dq_node(t_deque_node *node)
@@ -62,10 +40,11 @@ void	debug_token_dq_node(t_deque_node *node)
 	while (node)
 	{
 		token = (t_token *)node->content;
-		ft_dprintf(2, "  str   :[%s]\n", token->str);
-		ft_dprintf(2, "  kind  :[%s]\n", get_token_kind_str(token->kind));
-		ft_dprintf(2, "  quote :[%s]\n", get_quote_str(token->quote));
-		ft_dprintf(2, "  concat:[%s]\n", get_concat_str(token->concat_next));
+		ft_dprintf(2, "  str      :[%s]\n", token->str);
+		print_is_quoted_arr(token);
+		ft_dprintf(2, "  kind     :[%s]\n", get_token_kind_str(token->kind));
+		ft_dprintf(2, "  quote    :[%s]\n", get_quote_str(token->quote));
+		ft_dprintf(2, "  concat   :[%s]\n", get_concat_str(token->concat_next));
 		node = node->next;
 		if (node)
 			ft_dprintf(STDERR_FILENO, "\n");

--- a/srcs/debug/debug_token_dq_sub.c
+++ b/srcs/debug/debug_token_dq_sub.c
@@ -1,0 +1,37 @@
+#include "ms_tokenize.h"
+
+char	*get_token_kind_str(t_token_kind kind)
+{
+	if (kind == TOKEN_KIND_WORD)
+		return ("w");
+	if (kind == TOKEN_KIND_OP_PIPE)
+		return ("|");
+	if (kind == TOKEN_KIND_OP_OR)
+		return ("||");
+	if (kind == TOKEN_KIND_OP_AND)
+		return ("&&");
+	if (kind == TOKEN_KIND_REDIRECT_IN)
+		return ("<");
+	if (kind == TOKEN_KIND_REDIRECT_HEREDOC)
+		return ("<<");
+	if (kind == TOKEN_KIND_REDIRECT_OUT)
+		return (">");
+	if (kind == TOKEN_KIND_REDIRECT_APPEND)
+		return (">>");
+	if (kind == TOKEN_KIND_PAREN_LEFT)
+		return ("(");
+	if (kind == TOKEN_KIND_PAREN_RIGHT)
+		return (")");
+	return ("Error");
+}
+
+char	*get_quote_str(t_quote quote)
+{
+	if (quote == QUOTE_SINGLE)
+		return ("\'");
+	if (quote == QUOTE_DOUBLE)
+		return ("\"");
+	if (quote == QUOTE_NONE)
+		return ("");
+	return ("Error");
+}

--- a/srcs/exec/expand/concat_tokens.c
+++ b/srcs/exec/expand/concat_tokens.c
@@ -4,24 +4,54 @@
 #include "ms_parse.h"
 #include "ft_deque.h"
 #include "ft_mem.h"
+#include "ft_string.h"
+#include "ft_sys.h"
 
-static char	*concat_token_str(t_deque_node *node1, t_deque_node *node2)
+static char	*concat_token_str(t_token *token1, t_token *token2)
 {
-	const t_token	*token1 = (t_token *)node1->content;
-	const t_token	*token2 = (t_token *)node2->content;
 	char			*concat_str;
 
 	concat_str = x_ft_strjoin(token1->str, token2->str);
 	return (concat_str);
 }
 
-static void	swap_next_token_str(t_deque_node *next, char *concat_str)
+static bool	*concat_is_quoted_arr(t_token *token1, t_token *token2)
+{
+	const size_t	len1 = ft_strlen(token1->str);
+	const size_t	len2 = ft_strlen(token2->str);
+	bool			*is_quoted_arr;
+	size_t			i;
+	size_t			j;
+
+	is_quoted_arr = (bool *)x_malloc(sizeof(bool) * (len1 + len2));
+	if (!is_quoted_arr)
+		ft_abort();
+	i = 0;
+	while (token1->str && token1->str[i])
+	{
+		is_quoted_arr[i] = token1->is_quoted_arr[i];
+		i++;
+	}
+	j = 0;
+	while (token2->str && token2->str[j])
+	{
+		is_quoted_arr[i + j] = token2->is_quoted_arr[j];
+		j++;
+	}
+	return (is_quoted_arr);
+}
+
+static void	swap_next_token_str_and_is_quoted_arr(t_deque_node *next, \
+													char *concat_str, \
+													bool **is_quoted_arr)
 {
 	t_token	*next_token;
 
 	next_token = (t_token *)next->content;
 	ft_free(&next_token->str);
 	next_token->str = concat_str;
+	ft_free(&next_token->is_quoted_arr);
+	next_token->is_quoted_arr = *is_quoted_arr;
 }
 
 // tokens=[token1]=[token2]-[token3]=[token4]
@@ -31,10 +61,12 @@ static void	concat_tokens_each(t_deque *tokens, t_deque_node **node)
 {
 	t_deque_node	*next;
 	char			*concat_str;
+	bool			*concat_is_quoted;
 
 	next = (*node)->next;
-	concat_str = concat_token_str(*node, next);
-	swap_next_token_str(next, concat_str);
+	concat_str = concat_token_str((*node)->content, next->content);
+	concat_is_quoted = concat_is_quoted_arr((*node)->content, next->content);
+	swap_next_token_str_and_is_quoted_arr(next, concat_str, &concat_is_quoted);
 	deque_pop_selected_node(tokens, *node);
 	deque_clear_node(node, del_token);
 	*node = next;

--- a/srcs/exec/expand/expansion.c
+++ b/srcs/exec/expand/expansion.c
@@ -26,6 +26,7 @@ static void	expand_token(t_token *token, t_context *context)
 	}
 	ft_free(&token->str);
 	token->str = joind_str;
+	set_is_quoted_value_to_arr(token);
 }
 
 static void	expand_tokens(t_deque *tokens, t_context *context)
@@ -53,10 +54,13 @@ static void	expand_tokens(t_deque *tokens, t_context *context)
 static void	expand_variables_inter(t_deque **tokens, t_context *context)
 {
 	expand_tokens(*tokens, context);
-	remove_empty_tokens(*tokens);
 	concat_tokens(*tokens);
+//	debug_token_dq(*tokens, "after concat");
+	remove_empty_tokens(*tokens);
 	split_expand_word(tokens);
+//	debug_token_dq(*tokens, "after split");
 	expand_wildcard(tokens);
+//	debug_token_dq(*tokens, "after wild");
 }
 
 static void	expand_variables_for_redirect(t_deque *redirect_list, \

--- a/srcs/exec/expand/expansion.c
+++ b/srcs/exec/expand/expansion.c
@@ -53,12 +53,13 @@ static void	expand_tokens(t_deque *tokens, t_context *context)
 
 static void	expand_variables_inter(t_deque **tokens, t_context *context)
 {
+//	debug_token_dq(*tokens, "before expand");
 	expand_tokens(*tokens, context);
+	split_expand_word(tokens);
+//	debug_token_dq(*tokens, "after split");
 	concat_tokens(*tokens);
 //	debug_token_dq(*tokens, "after concat");
 	remove_empty_tokens(*tokens);
-	split_expand_word(tokens);
-//	debug_token_dq(*tokens, "after split");
 	expand_wildcard(tokens);
 //	debug_token_dq(*tokens, "after wild");
 }

--- a/srcs/exec/expand/split_expand_word.c
+++ b/srcs/exec/expand/split_expand_word.c
@@ -3,17 +3,22 @@
 #include "ms_tokenize.h"
 #include "ms_parse.h"
 #include "ft_deque.h"
+#include "ft_string.h"
 
 static void	create_split_tokens_each(t_deque_node *node, t_deque *expanded)
 {
 	t_token	*token;
+	char	*str_in_delim;
 
 	token = (t_token *)node->content;
-	if (token->quote != QUOTE_NONE)
+	str_in_delim = ft_find_set_in_str(token->str, TOKEN_DELIM);
+	if (token->quote == QUOTE_SINGLE || token->quote == QUOTE_DOUBLE)
+		deque_add_back(expanded, node);
+	else if (ft_streq(str_in_delim, "\0"))
 		deque_add_back(expanded, node);
 	else
 	{
-		word_split_and_add(token->str, expanded);
+		word_split_and_add(token->str, expanded, token->concat_next);
 		deque_clear_node(&node, del_token);
 	}
 }
@@ -38,9 +43,8 @@ static t_deque	*create_split_tokens_all(t_deque *tokens)
 	return (expanded_tokens);
 }
 
-// tokens=[token1]=[token2]-[token3]=[token4]
-//    ->  [token1token2]-[token3token4]
-// if concat_next=true; next token exist
+// tokens=[word1  word2]
+//    ->  [word1]-[word2]
 void	split_expand_word(t_deque **tokens)
 {
 	t_deque	*expanded;

--- a/srcs/exec/expand/word_split.c
+++ b/srcs/exec/expand/word_split.c
@@ -33,11 +33,14 @@ static char	*get_split_str(char *head, char **end)
 
 // [   aaa  bbb ccc] -> [aaa],[bbb],[ccc]
 // [key1  key2=a  b   c] -> [key1],[key2=a],[b],[c]
-void	word_split_and_add(char *token_str, t_deque *expanded)
+void	word_split_and_add(char *token_str, \
+							t_deque *expanded, \
+							bool concat_next)
 {
 	char			*split_str;
 	char			*end;
 	t_deque_node	*node;
+	t_token			*token;
 
 	while (*token_str)
 	{
@@ -48,4 +51,6 @@ void	word_split_and_add(char *token_str, t_deque *expanded)
 		deque_add_back(expanded, node);
 		token_str = end;
 	}
+	token = (t_token *)node->content;
+	token->concat_next = concat_next;
 }

--- a/srcs/parse/ast_dup_token.c
+++ b/srcs/parse/ast_dup_token.c
@@ -12,6 +12,7 @@ static t_token	*dup_token(t_token *token)
 	new_token->kind = token->kind;
 	new_token->quote = token->quote;
 	new_token->concat_next = token->concat_next;
+	set_is_quoted_value_to_arr(new_token);
 	return (new_token);
 }
 

--- a/srcs/tokenize/del_token.c
+++ b/srcs/tokenize/del_token.c
@@ -10,6 +10,7 @@ void	del_token(void *content)
 		return ;
 	token = (t_token *)content;
 	ft_free(&token->str);
+	ft_free(&token->is_quoted_arr);
 	ft_free(&token);
 }
 

--- a/srcs/tokenize/set_is_quoted_arr.c
+++ b/srcs/tokenize/set_is_quoted_arr.c
@@ -1,0 +1,42 @@
+#include <stdlib.h>
+#include "minishell.h"
+#include "ms_tokenize.h"
+#include "ft_deque.h"
+#include "ft_mem.h"
+#include "ft_string.h"
+#include "ft_sys.h"
+
+static bool	get_is_quoted_value(t_quote quote)
+{
+	return (quote != QUOTE_NONE);
+}
+
+void	set_is_quoted_value_to_arr(t_token *token)
+{
+	const char		*token_str = token->str;
+	const size_t	len = ft_strlen(token_str);
+	bool			*is_quoted_arr;
+	bool			is_quoted_value;
+
+	if (token->kind != TOKEN_KIND_WORD)
+		return ;
+	is_quoted_arr = (bool *)x_malloc(sizeof(bool) * len);
+	if (!is_quoted_arr)
+		ft_abort();
+	is_quoted_value = get_is_quoted_value(token->quote);
+	ft_memset(is_quoted_arr, is_quoted_value, sizeof(bool) * len);
+	ft_free(&token->is_quoted_arr);
+	token->is_quoted_arr = is_quoted_arr;
+}
+
+void	set_is_quoted_arr(t_deque *tokens)
+{
+	t_deque_node	*token_node;
+
+	token_node = tokens->node;
+	while (token_node)
+	{
+		set_is_quoted_value_to_arr(token_node->content);
+		token_node = token_node->next;
+	}
+}

--- a/srcs/tokenize/tokenize.c
+++ b/srcs/tokenize/tokenize.c
@@ -51,6 +51,7 @@ t_deque	*tokenize(char *line, t_context *context, t_result *result)
 	}
 	set_token_quote_type_all(tokens);
 	remove_quote_in_token_str(tokens);
+	set_is_quoted_arr(tokens);
 	// debug_token_dq(tokens, "tokenize");
 	return (tokens);
 }

--- a/srcs/tokenize/tokenize_line.c
+++ b/srcs/tokenize/tokenize_line.c
@@ -14,6 +14,7 @@ t_token	*init_token_struct(void)
 	token->str = NULL;
 	token->kind = TOKEN_KIND_WORD;
 	token->quote = QUOTE_NONE;
+	token->is_quoted_arr = NULL;
 	token->concat_next = false;
 	return (token);
 }

--- a/srcs/tokenize/tokenize_line.c
+++ b/srcs/tokenize/tokenize_line.c
@@ -35,6 +35,7 @@ t_deque_node	*create_token_node(char *token_str, char next_chr)
 	t_deque_node	*node;
 
 	token = create_token_struct(token_str, next_chr);
+	set_is_quoted_value_to_arr(token);
 	node = deque_node_new(token);
 	if (!node)
 		ft_abort();


### PR DESCRIPTION
- [x] wildcard判定用にtoken_strの各文字に対し、quoted=1, un-quoted=0なる`bool *is_quoted_arr`を追加
- [x] `expand_variables_inter()`内の関数`expand_var(), split_token(), concat_token(), remove_empty()`の実行順を変更（以下修正のため）
  - remove_empty()によりconcat先が後ろのtokenになってしまう挙動を修正
    - `a$nothing"b"` など、結合がある`$nothing`が`remove_empty()`で消滅した際、`a`の`concat_next`により`a`, `"b"`が結合していた 
  - split, concatが共に有効な際の挙動を修正
    - `export A="a    b"; echo $A"$A"`
  

#243 で quote の判定に使用する