### PR TITLE
fix: handle empty command

### DIFF
--- a/srcs/path/create_exec_path.c
+++ b/srcs/path/create_exec_path.c
@@ -20,7 +20,7 @@ static char	*search_command_path(const char *const command, t_var *var)
 	char	*env_path;
 	char	*exec_path;
 
-	if (ft_strlen(command) == 0)
+	if (command && !*command)
 		return (NULL);
 	env_path = create_split_src_paths(var, KEY_PATH);
 	exec_path = create_executable_path(env_path, command);

--- a/srcs/path/create_exec_path.c
+++ b/srcs/path/create_exec_path.c
@@ -20,6 +20,8 @@ static char	*search_command_path(const char *const command, t_var *var)
 	char	*env_path;
 	char	*exec_path;
 
+	if (ft_strlen(command) == 0)
+		return (NULL);
 	env_path = create_split_src_paths(var, KEY_PATH);
 	exec_path = create_executable_path(env_path, command);
 	if (exec_path)

--- a/srcs/path/create_exec_path.c
+++ b/srcs/path/create_exec_path.c
@@ -14,13 +14,18 @@ static bool	is_slash_in_argv(const char *const argv_head)
 	return (false);
 }
 
+static bool	is_empty_command(const char *const command)
+{
+	return (command && !*command);
+}
+
 // access(PATH[i] + "/" " command)
 static char	*search_command_path(const char *const command, t_var *var)
 {
 	char	*env_path;
 	char	*exec_path;
 
-	if (command && !*command)
+	if (is_empty_command(command))
 		return (NULL);
 	env_path = create_split_src_paths(var, KEY_PATH);
 	exec_path = create_executable_path(env_path, command);


### PR DESCRIPTION
* `$ ""`の挙動を修正
  - before : Permission denied (status=126)
  - after : command not found (status=127)
* 修正箇所
  - `""`入力の際にPATH検索のルートを変更
  - `/`がないためPATH検索に入り、PATH[0] + `""`でディレクトリにヒットし、exec(dir)でpermission deniedになっていた
  - strlen(cmd) == 0の時にexec_path=NULLとし、command not found判定にするよう変更


issue: #251 