### PR TITLE
ambiguous redirects arg

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -247,6 +247,7 @@ t		: all
 # test all
 .PHONY		: test_all
 test_all	: all
+	$(shell rm ko_case_*.txt)
 	python3 ./test/integration_test/run_all.py
 
 # test multi pipe

--- a/includes/ms_expansion.h
+++ b/includes/ms_expansion.h
@@ -13,13 +13,17 @@
 # define HIDDEN_FILE	'.'
 # define WILDCARD		'*'
 
+# define ERROR_MSG_AMBIGUOUS		"ambiguous redirect"
+# define STATUS_REDIRECT_FAILURE	1
+
 typedef struct s_ast		t_ast;
 typedef struct s_context	t_context;
 typedef struct s_deque		t_deque;
 typedef struct s_redirect	t_redirect;
 typedef struct s_token		t_token;
 
-t_result	expand_variables(t_ast *self_node, t_context *context);
+void		expand_variable_of_cmd_tokens(t_ast *self_node, t_context *context);
+void		expand_processing(t_deque **tokens, t_context *context);
 char		*get_expand_token_str(char *str, t_context *context);
 char		*substr_before_dollar(char **str);
 void		remove_empty_tokens(t_deque *tokens);

--- a/srcs/exec/exec.c
+++ b/srcs/exec/exec.c
@@ -47,8 +47,7 @@ static t_result	execute_command_internal(t_ast *self_node, t_context *context)
 {
 	t_result	result;
 
-	if (expand_variables(self_node, context) == PROCESS_ERROR)
-		return (PROCESS_ERROR);
+	expand_variable_of_cmd_tokens(self_node, context);
 	result = redirect_fd(self_node, context);
 	if ((result == PROCESS_ERROR) || (result == FAILURE))
 	{

--- a/srcs/exec/expand/expansion.c
+++ b/srcs/exec/expand/expansion.c
@@ -38,56 +38,17 @@ static void	expand_tokens(const t_deque *tokens, t_context *context)
 	}
 }
 
-static void	expand_variables_inter(t_deque **tokens, t_context *context)
+void	expand_processing(t_deque **tokens, t_context *context)
 {
-//	debug_token_dq(*tokens, "before expand");
-//	ft_dprintf(2, "1 tokens:%p\n", *tokens);
 	expand_tokens(*tokens, context);
-//	debug_token_dq(*tokens, "after expand");
 	split_expand_word(tokens);
-//	debug_token_dq(*tokens, "after split");
 	concat_tokens(*tokens);
 	remove_empty_tokens(*tokens);
-//	debug_token_dq(*tokens, "after remove");
 	expand_wildcard(tokens);
-	// debug_token_dq(*tokens, "after wild");
-}
-
-static t_result	expand_variables_for_redirect(const t_deque *redirect_list, \
-												t_context *context)
-{
-	t_deque_node	*list_node;
-	t_redirect		*redirect;
-	t_result		result;
-
-	if (!redirect_list)
-		return (SUCCESS);
-	list_node = redirect_list->node;
-	while (list_node)
-	{
-		redirect = (t_redirect *)list_node->content;
-		if (redirect->kind == TOKEN_KIND_REDIRECT_HEREDOC)
-		{
-			result = expand_for_heredoc(redirect, context);
-			if (result == PROCESS_ERROR)
-				return (PROCESS_ERROR);
-			list_node = list_node->next;
-			continue ;
-		}
-		expand_variables_inter(&redirect->tokens, context);
-		split_expand_word(&redirect->tokens);
-		list_node = list_node->next;
-	}
-	return (SUCCESS);
 }
 
 // word splitting: if unquoted, word split by delimiter
-t_result	expand_variables(t_ast *self_node, t_context *context)
+void	expand_variable_of_cmd_tokens(t_ast *self_node, t_context *context)
 {
-	t_result	result;
-
-	result = SUCCESS;
-	expand_variables_inter(&self_node->command, context);
-	result = expand_variables_for_redirect(self_node->redirect_list, context);
-	return (result);
+	expand_processing(&self_node->command, context);
 }


### PR DESCRIPTION
- [x] ambiguous redirect errorのargが展開前のtokenのため、redirectのexpansionをredirect fd操作直前に実施するよう変更
- [x] （ついでに） run test_all の実行前にko_case_*.txtを削除

issue : #261 