### PR TITLE
interpret -i option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,8 @@ endif
 MKDIR		:=	mkdir -p
 
 SRCS_DIR	:=	srcs
-SRCS		:=	destroy.c \
+SRCS		:=	analyze_minishell_option.c \
+				destroy.c \
 				init.c \
 				main.c \
 				repl.c

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -32,6 +32,8 @@
 # define EMPTY_STR				"\0"
 # define SPACE					' '
 
+# define OPTION_FORCED_INTERACTIVE	'i'
+
 /* status */
 // tokenize and parse
 # define SYNTAX_ERROR				2
@@ -123,8 +125,10 @@ char		*get_random_str(const size_t size);
 char		*ft_get_next_line(int fd, t_result *result);
 
 /* init */
-void		init_context(t_context *context);
-
+void		init_context(t_context *context, bool is_is_forced_interactive);
+t_result	analyze_option(int argc, \
+								char **argv, \
+								bool *is_is_forced_interactive);
 /* repl */
 t_result	read_eval_print_loop(t_context *context);
 

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -125,10 +125,9 @@ char		*get_random_str(const size_t size);
 char		*ft_get_next_line(int fd, t_result *result);
 
 /* init */
-void		init_context(t_context *context, bool is_is_forced_interactive);
-t_result	analyze_option(int argc, \
-								char **argv, \
-								bool *is_is_forced_interactive);
+void		init_context(t_context *context, bool is_forced_interactive);
+t_result	analyze_option(int argc, char **argv, bool *is_forced_interactive);
+
 /* repl */
 t_result	read_eval_print_loop(t_context *context);
 

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -33,6 +33,7 @@
 # define SPACE					' '
 
 # define OPTION_FORCED_INTERACTIVE	'i'
+# define INVALID_OPTION				2
 
 /* status */
 // tokenize and parse

--- a/includes/ms_builtin.h
+++ b/includes/ms_builtin.h
@@ -46,7 +46,6 @@
 # define TOO_MANY_ARG_STATUS	1
 
 # define NOT_A_VALID_IDENTIFIER	1
-# define INVALID_OPTION			2
 
 # define CD_ERROR_STATUS		1
 

--- a/includes/ms_builtin.h
+++ b/includes/ms_builtin.h
@@ -55,6 +55,7 @@
 # define ERROR_MSG_TOO_MANY_ARG	"too many arguments"
 # define ERROR_MSG_REQUIRED_NUM	"numeric argument required"
 # define ERROR_MSG_INVALID_OP	"invalid option"
+# define ERROR_MSG_INVALID_ARG	"invalid argument"
 # define ERROR_MSG_NOT_VALID_ID	"not a valid identifier"
 # define ERROR_MSG_NOT_SET		"not set"
 

--- a/srcs/analyze_minishell_option.c
+++ b/srcs/analyze_minishell_option.c
@@ -20,9 +20,9 @@ static void	skip_while_valid_option(char ***argv, bool *is_forced_interactive)
 
 t_result	analyze_option(int argc, char **argv, bool *is_forced_interactive)
 {
-	*is_forced_interactive = false;
 	if (argc == 1)
 		return (SUCCESS);
+	*is_forced_interactive = false;
 	argv++;
 	skip_while_valid_option(&argv, is_forced_interactive);
 	if (is_end_of_option(*argv))

--- a/srcs/analyze_minishell_option.c
+++ b/srcs/analyze_minishell_option.c
@@ -18,9 +18,7 @@ static void	skip_while_valid_option(char ***argv, bool *is_forced_interactive)
 	}
 }
 
-t_result	analyze_option(int argc, \
-								char **argv, \
-								bool *is_forced_interactive)
+t_result	analyze_option(int argc, char **argv, bool *is_forced_interactive)
 {
 	*is_forced_interactive = false;
 	if (argc == 1)

--- a/srcs/analyze_minishell_option.c
+++ b/srcs/analyze_minishell_option.c
@@ -1,0 +1,36 @@
+#include "minishell.h"
+#include "ms_builtin.h"
+
+static void	put_option_error(char *arg)
+{
+	if (arg[0] == CMD_OPTION_MARKER)
+		puterr_cmd_msg(arg, ERROR_MSG_INVALID_OP);
+	else
+		puterr_cmd_msg(arg, ERROR_MSG_INVALID_ARG);
+}
+
+static void	skip_while_valid_option(char ***argv, bool *is_forced_interactive)
+{
+	while (is_arg_option(**argv, CMD_OPTION_MARKER, OPTION_FORCED_INTERACTIVE))
+	{
+		(*argv)++;
+		*is_forced_interactive = true;
+	}
+}
+
+t_result	analyze_option(int argc, \
+								char **argv, \
+								bool *is_forced_interactive)
+{
+	*is_forced_interactive = false;
+	if (argc == 1)
+		return (SUCCESS);
+	argv++;
+	skip_while_valid_option(&argv, is_forced_interactive);
+	if (is_end_of_option(*argv))
+		argv++;
+	if (!*argv)
+		return (SUCCESS);
+	put_option_error(*argv);
+	return (FAILURE);
+}

--- a/srcs/init.c
+++ b/srcs/init.c
@@ -13,9 +13,9 @@ static void	set_context_initial_value(t_context *context)
 }
 
 // If an error occurs, will not exit.
-static bool	set_is_interactive(bool is_is_forced_interactive)
+static bool	set_is_interactive(bool is_forced_interactive)
 {
-	if (is_is_forced_interactive)
+	if (is_forced_interactive)
 		return (true);
 	return (isatty(STDIN_FILENO) && isatty(STDOUT_FILENO));
 }

--- a/srcs/init.c
+++ b/srcs/init.c
@@ -13,26 +13,28 @@ static void	set_context_initial_value(t_context *context)
 }
 
 // If an error occurs, will not exit.
-static bool	set_is_interactive(void)
+static bool	set_is_interactive(bool is_is_forced_interactive)
 {
-	return (true);
-	// return (isatty(STDIN_FILENO) && isatty(STDOUT_FILENO));
+	if (is_is_forced_interactive)
+		return (true);
+	return (isatty(STDIN_FILENO) && isatty(STDOUT_FILENO));
 }
 
 // set_default_environ set also PWD, OLDPWD.
-static void	set_context_default_value(t_context *context)
+static void	set_context_default_value(t_context *context, \
+										bool is_forced_interactive)
 {
 	t_var	*var;
 
 	context->var = set_default_environ();
 	var = context->var;
 	context->internal_pwd = var->get_value(var, KEY_PWD);
-	context->is_interactive = set_is_interactive();
+	context->is_interactive = set_is_interactive(is_forced_interactive);
 	context->status = EXIT_SUCCESS;
 }
 
-void	init_context(t_context *context)
+void	init_context(t_context *context, bool is_forced_interactive)
 {
 	set_context_initial_value(context);
-	set_context_default_value(context);
+	set_context_default_value(context, is_forced_interactive);
 }

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -1,6 +1,5 @@
 #include <stdlib.h>
 #include "minishell.h"
-#include "ms_builtin.h"
 
 int	main(int argc, char **argv)
 {

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -1,12 +1,16 @@
 #include <stdlib.h>
 #include "minishell.h"
+#include "ms_builtin.h"
 
-int	main(void)
+int	main(int argc, char **argv)
 {
 	t_context	context;
 	t_result	result;
+	bool		is_forced_interactive;
 
-	init_context(&context);
+	if (analyze_option(argc, argv, &is_forced_interactive) == FAILURE)
+		return (INVALID_OPTION);
+	init_context(&context, is_forced_interactive);
 	result = read_eval_print_loop(&context);
 	destroy_context(context);
 	if (result == PROCESS_ERROR)

--- a/test/integration_test/test_functions.py
+++ b/test/integration_test/test_functions.py
@@ -4,7 +4,8 @@ import subprocess
 
 # ----------------------------------------------------------
 # OUT_FILE = "pipe_test_out.txt"
-PATH_MINISHELL = "./minishell"
+PATH_MINISHELL = ["./minishell", "-i"]
+PATH_MINISHELL_LEAK = "./minishell"
 BASH_INIT_FILE = 'bash_init_file'
 PATH_BASH = ["/bin/bash", "--init-file", BASH_INIT_FILE, "-i"]
 PATH_BASH_LEAK = "bash"
@@ -125,7 +126,7 @@ def run_both_with_valgrind(stdin):
     if shutil.which("valgrind") is None:
         return None, None
 
-    leak_res_minishell = run_minishell_with_valgrind(stdin, PATH_MINISHELL)
+    leak_res_minishell = run_minishell_with_valgrind(stdin, PATH_MINISHELL_LEAK)
     leak_res_bash = run_bash_with_valgrind(stdin, PATH_BASH_LEAK)
     return leak_res_minishell, leak_res_bash
 


### PR DESCRIPTION
* `-i` optionでforced_interactiveにするよう変更
* 他のbuiltinのオプションと同様、`-i -i -i` ,`-iii`なども有効なオプションと解釈する
* -i 以外のoptionが入力された場合はinvalid option error (status=2)
* `--`までをoptionと判定、以降を引数とし、引数が1以上あればinvalid argument error (status=2)

issue: #239 