### PR TITLE
update(exit/exec)

### DIFF
--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -81,6 +81,7 @@ typedef struct s_context
 	bool	is_interactive;
 	char	*internal_pwd;
 	uint8_t	status;
+	uint8_t	is_return;
 }	t_context;
 
 // temporarily here ...

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -81,7 +81,7 @@ typedef struct s_context
 	bool	is_interactive;
 	char	*internal_pwd;
 	uint8_t	status;
-	uint8_t	is_return;
+	bool	is_return;
 }	t_context;
 
 // temporarily here ...

--- a/srcs/builtin/ft_exit.c
+++ b/srcs/builtin/ft_exit.c
@@ -76,6 +76,9 @@ uint8_t	ft_exit(const char *const *argv, t_context *context)
 		ft_dprintf(STDERR_FILENO, "%s\n", CMD_EXIT);
 	put_exit_err(argv[EXIT_ARG_IDX], arg_result);
 	if (!is_exit(arg_result))
+	{
+		context->is_return = true;
 		return (status);
+	}
 	exit(status);
 }

--- a/srcs/exec/handle_node.c
+++ b/srcs/exec/handle_node.c
@@ -1,4 +1,4 @@
-#include <sys/wait.h>
+#include <stdlib.h>
 #include "minishell.h"
 #include "ms_exec.h"
 #include "ms_tokenize.h"
@@ -28,7 +28,7 @@ static bool	is_executable_right_node(t_ast *self_node, t_context *context)
 		return (false);
 	if (!is_node_kind_and_or(self_node->kind))
 		return (true);
-	if (self_node->kind == NODE_KIND_OP_AND && context->status == 0)
+	if (self_node->kind == NODE_KIND_OP_AND && context->status == EXIT_SUCCESS)
 		return (true);
 	if (self_node->kind == NODE_KIND_OP_OR && context->status != EXIT_SUCCESS)
 		return (true);

--- a/srcs/exec/handle_node.c
+++ b/srcs/exec/handle_node.c
@@ -30,7 +30,7 @@ static bool	is_executable_right_node(t_ast *self_node, t_context *context)
 		return (true);
 	if (self_node->kind == NODE_KIND_OP_AND && context->status == 0)
 		return (true);
-	if (self_node->kind == NODE_KIND_OP_OR && context->status != 0)
+	if (self_node->kind == NODE_KIND_OP_OR && context->status != EXIT_SUCCESS)
 		return (true);
 	return (false);
 }

--- a/srcs/exec/handle_node.c
+++ b/srcs/exec/handle_node.c
@@ -22,21 +22,23 @@ t_result	exec_handle_left_node(t_ast *self_node, t_context *context)
 }
 
 // &&, ||
-static bool	is_executable_right_node(t_ast *self_node, uint8_t status)
+static bool	is_executable_right_node(t_ast *self_node, t_context *context)
 {
+	if (context->is_return)
+		return (false);
 	if (!is_node_kind_and_or(self_node->kind))
 		return (true);
-	if (self_node->kind == NODE_KIND_OP_AND && status == 0)
+	if (self_node->kind == NODE_KIND_OP_AND && context->status == 0)
 		return (true);
-	if (self_node->kind == NODE_KIND_OP_OR && status != 0)
+	if (self_node->kind == NODE_KIND_OP_OR && context->status != 0)
 		return (true);
 	return (false);
 }
 
 static bool	is_matching_condition_of_traverse_right_node(t_ast *self_node, \
-															uint8_t status)
+															t_context *context)
 {
-	if (!is_executable_right_node(self_node, status))
+	if (!is_executable_right_node(self_node, context))
 		return (false);
 	if (self_node->kind != NODE_KIND_SUBSHELL && self_node->right)
 		return (true);
@@ -45,8 +47,7 @@ static bool	is_matching_condition_of_traverse_right_node(t_ast *self_node, \
 
 t_result	exec_handle_right_node(t_ast *self_node, t_context *context)
 {
-	if (!is_matching_condition_of_traverse_right_node(self_node, \
-														context->status))
+	if (!is_matching_condition_of_traverse_right_node(self_node, context))
 		return (SUCCESS);
 	if (execute_command(self_node->right, context) == PROCESS_ERROR)
 		return (PROCESS_ERROR);

--- a/srcs/exec/redirects.c
+++ b/srcs/exec/redirects.c
@@ -77,7 +77,7 @@ static t_result	expand_and_exec_redirect_all(t_ast *self_node, \
 	return (SUCCESS);
 }
 
-t_result	close_prod_fd_id_exit(t_ast *self_node)
+t_result	close_prod_fd_if_exit(t_ast *self_node)
 {
 	if (self_node->proc_fd[IN] != IN_FD_INIT)
 	{

--- a/srcs/exec/redirects.c
+++ b/srcs/exec/redirects.c
@@ -77,7 +77,7 @@ static t_result	expand_and_exec_redirect_all(t_ast *self_node, \
 	return (SUCCESS);
 }
 
-t_result	close_prod_fd_if_exit(t_ast *self_node)
+t_result	close_prod_fd_for_exit_command(t_ast *self_node)
 {
 	if (self_node->proc_fd[IN] != IN_FD_INIT)
 	{
@@ -104,7 +104,7 @@ t_result	redirect_fd(t_ast *self_node, t_context *context)
 		return (result);
 	if (ft_streq(command, CMD_EXIT))
 	{
-		if (close_prod_fd_id_exit(self_node) == PROCESS_ERROR)
+		if (close_prod_fd_for_exit_command(self_node) == PROCESS_ERROR)
 			return (PROCESS_ERROR);
 		return (SUCCESS);
 	}

--- a/srcs/exec/redirects.c
+++ b/srcs/exec/redirects.c
@@ -77,12 +77,8 @@ static t_result	expand_and_exec_redirect_all(t_ast *self_node, \
 	return (SUCCESS);
 }
 
-t_result	close_exit_fd(t_ast *self_node)
+t_result	close_prod_fd_id_exit(t_ast *self_node)
 {
-	const char	*command = get_head_token_str(self_node->command);
-
-	if (!ft_streq(command, CMD_EXIT))
-		return (SUCCESS);
 	if (self_node->proc_fd[IN] != IN_FD_INIT)
 	{
 		if (x_close(self_node->proc_fd[IN]) == PROCESS_ERROR)
@@ -98,6 +94,7 @@ t_result	close_exit_fd(t_ast *self_node)
 
 t_result	redirect_fd(t_ast *self_node, t_context *context)
 {
+	const char	*command = get_head_token_str(self_node->command);
 	t_result	result;
 
 	if (!self_node->redirect_list)
@@ -105,10 +102,14 @@ t_result	redirect_fd(t_ast *self_node, t_context *context)
 	result = expand_and_exec_redirect_all(self_node, context);
 	if (result == FAILURE || result == PROCESS_ERROR)
 		return (result);
+	if (ft_streq(command, CMD_EXIT))
+	{
+		if (close_prod_fd_id_exit(self_node) == PROCESS_ERROR)
+			return (PROCESS_ERROR);
+		return (SUCCESS);
+	}
 	result = connect_redirect_to_proc(self_node);
 	if (result == PROCESS_ERROR)
-		return (PROCESS_ERROR);
-	if (close_exit_fd(self_node) == PROCESS_ERROR)
 		return (PROCESS_ERROR);
 	return (SUCCESS);
 }

--- a/srcs/init.c
+++ b/srcs/init.c
@@ -10,6 +10,7 @@ static void	set_context_initial_value(t_context *context)
 	context->internal_pwd = NULL;
 	context->is_interactive = false;
 	context->status = EXIT_SUCCESS;
+	context->is_return = false;
 }
 
 // If an error occurs, will not exit.

--- a/srcs/repl.c
+++ b/srcs/repl.c
@@ -14,6 +14,7 @@ t_result	read_eval_print_loop(t_context *context)
 
 	while (true)
 	{
+		context->is_return = false;
 		result = SUCCESS;
 		line = input_line();
 		if (!line)

--- a/test/integration_test/run_exit.py
+++ b/test/integration_test/run_exit.py
@@ -4,8 +4,7 @@ from test_functions import test
 def main():
 
     test_res = 0
-    exit_test = [
-                "tty",
+    exit_test = ["tty",
                 "exit",
                  "exit 0",
                  "exit 1",
@@ -67,6 +66,9 @@ def main():
                  "exit \f42",
                  "exit \r42",
                  "exit \r\r42",
+                 "exit 1 1 1 && exit 2 2 2 || exit 3",
+                 "echo a >in && <in exit 1 1 1 <in >out && rm in out  && exit 2 2 2",
+                 " exit 1 | exit 2 | exit 3 && echo a || echo b && exit 1 1 1 || echo 42 && echo hello >out"
                  ]  # add more test after update tokenizer
 
     test_res |= test("ft_exit", exit_test, False)


### PR DESCRIPTION
- [x] exit が main procで実行されexitされない引数の際には、後続のコマンドを実行せずにreplに戻るらしい
- [x] ft_exit内でis_return flagを変更し、exec でright_nodeの実行可否を決定した
```shell
$ exit 5 5 && echo bb || exit 9
exit
bash: exit: too many arguments
```