### PR TITLE
Update redirect use /dev/stdin, /dev/stdout

### DIFF
--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -62,6 +62,7 @@
 /* parse, exec */
 # define IN_FD_INIT		STDIN_FILENO
 # define OUT_FD_INIT	STDOUT_FILENO
+# define REDIRECT_USED	(-1)
 
 /* utils */
 # define RANDOM_FILENAME	"/dev/urandom"

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -60,9 +60,9 @@
 # define ERROR_MSG_RETRIEVE_CWD	"error retrieving current directory"
 
 /* parse, exec */
-# define IN_FD_INIT		STDIN_FILENO
-# define OUT_FD_INIT	STDOUT_FILENO
-# define REDIRECT_USED	(-1)
+# define IN_FD_INIT			STDIN_FILENO
+# define OUT_FD_INIT		STDOUT_FILENO
+# define REDIRECT_FAILURE	(-1)
 
 /* utils */
 # define RANDOM_FILENAME	"/dev/urandom"

--- a/includes/ms_exec.h
+++ b/includes/ms_exec.h
@@ -21,6 +21,9 @@
 # define STATUS_CMD_NOT_FOUND		127
 # define REDIRECT_ONLY_SUCCESS		0
 
+# define DEV_STDIN_PATH		"/dev/stdin"
+# define DEV_STDOUT_PATH	"/dev/stdout"
+
 # define STDIO_COPY_INIT	(-1)
 
 # define ERROR_MSG_NO_SUCH_FILE			"No such file or directory"

--- a/includes/ms_exec.h
+++ b/includes/ms_exec.h
@@ -72,11 +72,11 @@ bool			is_command_builtin(const char *cmd);
 /* ast */
 char			**convert_command_to_argv(t_deque *command);
 t_result		handle_child_pipes(t_ast *self_node);
-void			child_process(t_ast *self_node, t_context *context);
+void			child_process(t_ast *self_node, t_context *context, t_result redirect_result);
 t_result		handle_parent_pipes(t_ast *self_node);
 t_result		parent_process(t_ast *self_node, t_context *context);
-t_result		exec_command_each(t_ast *self_node, t_context *context);
-void			execute_single_builtin(t_ast *self_node, t_context *context);
+t_result		exec_command_each(t_ast *self_node, t_context *context, t_result redirect_result);
+void			execute_single_builtin(t_ast *self_node, t_context *context, t_result redirect_result);
 bool			is_single_builtin_command(const t_ast *self_node);
 bool			is_last_command_node(t_ast *self_node);
 char			*get_head_token_str(const t_deque *command);
@@ -92,7 +92,7 @@ t_result		exec_handle_right_node(t_ast *self_node, t_context *context);
 t_redirect		*init_redirect(void);
 void			del_redirect(void *content);
 t_result		redirect_fd(t_ast *self_node, t_context *context);
-t_result		connect_redirect_to_proc(t_ast *self_node);
+t_result		connect_redirect_to_proc(int *prev_fd, int proc_fd[2]);
 t_result		open_redirect_fd_and_save_to_proc(t_redirect *redirect, \
 													int proc_fd[2], \
 													int *open_errno);

--- a/includes/ms_exec.h
+++ b/includes/ms_exec.h
@@ -58,7 +58,7 @@ t_result		execute_command(t_ast **self_node, \
 								t_context *context, \
 								t_result heredoc_result);
 t_result		execute_command_recursive(t_ast *self_node, t_context *context);
-t_result		copy_stdio_fd(int *stdin_copy, \
+t_result		backup_stdio_fd(int *stdin_copy, \
 								int *stdout_copy, \
 								const t_ast *self_node);
 t_result		restore_stdio_fd(int stdin_copy, int stdout_copy);
@@ -98,5 +98,7 @@ t_result		open_redirect_fd_and_save_to_proc(t_redirect *redirect, \
 													int *open_errno);
 t_result		close_proc_in_fd(int *proc_in_fd);
 t_result		close_proc_out_fd(int *proc_out_fd);
+bool			is_use_redirect_in(int proc_in_fd);
+bool			is_use_redirect_out(int proc_out_fd);
 
 #endif //MS_EXEC_H

--- a/playground/ta/chdir/test_chdir.c
+++ b/playground/ta/chdir/test_chdir.c
@@ -1,18 +1,67 @@
 #include <stdio.h>
 #include <unistd.h>
+#include <string.h>
+#include <errno.h>
+#include <stdlib.h>
 
 int	main(void)
 {
+	int		 err;
+//	char	*path = "/home/user42/42tokyo/minishell/link";
 
-	chdir("/bin");// todo : move to /usr/bin with chdir("/bin") ??
+//	printf("1. cd link\n");
+	errno = 0;
+	chdir("link");
+//	chdir(path);
+	err = errno;
+	printf("path:%s, err:%d, %s\n\n", getcwd(NULL, 0), err, strerror(err));
 
-	printf("path:%s\n", getcwd(NULL, 0));
+	printf("2. cd ../srcs/././\n");
+	err = errno;
 
-	char *cmd[] = {"/bin/pwd", NULL};
-	execve(cmd[0], cmd, NULL);
+	// pwd    = "/home/user42/42tokyo/minishell/link"
+	// arg    = ".."
+	// cdpath = "/home/user42/42tokyo/minishell/link/.."
+    //        = "/home/user42/42tokyo/minishell"          <- linkなら展開されるので`path_i/../`を削除
 
-//	char *cmd[] = {"/bin/ls", NULL};
-//	execve(cmd[0], cmd, NULL);
+	// pwd    = "/home/user42/42tokyo/minishell"
+	// arg    = "srcs"
+	// cdpath = "/home/user42/42tokyo/minishell/srcs" -> failure
+
+	// pwd    = "/home/user42/42tokyo/minishell/srcs"
+	// arg    = "."
+	// cdpath = "/home/user42/42tokyo/minishell/srcs/."
+	//        = "/home/user42/42tokyo/minishell/srcs"
+
+
+	// ../../
+	// "home/user42/42tokyo/minishell/testdir/ng_or_deleted"
+
+	// "home/user42/42tokyo/minishell/testdir/ng_or_deleted/../"
+	// "home/user42/42tokyo/minishell/testdir/"
+
+
+	// ../../../
+	// "home/user42/42tokyo/minishell/testdir/ng/ok"
+
+	// "home/user42/42tokyo/minishell/testdir/ng/ok/.."
+	// "home/user42/42tokyo/minishell/testdir/ng"        <- failue
+
+
+	chdir("/home/user42/42tokyo/minishell/");
+	printf("path:%s, err:%d, %s\n\n", getcwd(NULL, 0), err, strerror(err));
+	chdir("/home/user42/42tokyo/minishell/srcs");
+	printf("path:%s, err:%d, %s\n\n", getcwd(NULL, 0), err, strerror(err));
+
+//	printf("3. cd ../dir3\n");
+//	chdir("../dir3");
+//	err = errno;
+//	printf("path:%s, err:%d, %s\n\n", getcwd(NULL, 0), err, strerror(err));
+
+
+//	printf("2. cd ../dir3\n");
+
+
 
 	return (0);
 }

--- a/srcs/exec/backup_fd.c
+++ b/srcs/exec/backup_fd.c
@@ -17,8 +17,8 @@ t_result	backup_stdio_fd(int *stdin_copy, \
 {
 	const char	*command = get_head_token_str(self_node->command);
 
-	*stdin_copy = STDIO_COPY_INIT;
-	*stdout_copy = STDIO_COPY_INIT;
+	*stdin_copy = IN_FD_INIT;
+	*stdout_copy = OUT_FD_INIT;
 	if (is_command_not_used_redirect(command))
 		return (SUCCESS);
 	if (is_use_redirect_in(self_node->proc_fd[IN]))
@@ -26,39 +26,23 @@ t_result	backup_stdio_fd(int *stdin_copy, \
 		*stdin_copy = x_dup(STDIN_FILENO);
 		if (*stdin_copy == DUP_ERROR)
 			return (PROCESS_ERROR);
+		ft_dprintf(2, "cmd[%s] backup stdin(%d)\n", command, *stdin_copy);
 	}
 	if (is_use_redirect_out(self_node->proc_fd[OUT]))
 	{
 		*stdout_copy = x_dup(STDOUT_FILENO);
 		if (*stdout_copy == DUP_ERROR)
 			return (PROCESS_ERROR);
+		ft_dprintf(2, "cmd[%s] backup stdout(%d)\n", command, *stdout_copy);
 	}
 	return (SUCCESS);
 }
-/*
-t_result	backup_stdio_fd(int *stdin_copy, \
-							int *stdout_copy, \
-							const t_ast *self_node)
-{
-	const char	*command = get_head_token_str(self_node->command);
 
-	*stdin_copy = IN_FD_INIT;
-	*stdout_copy = OUT_FD_INIT;
-	if (is_command_not_used_redirect(command))
-		return (SUCCESS);
-	*stdin_copy = x_dup(STDIN_FILENO);
-	if (*stdin_copy == DUP_ERROR)
-		return (PROCESS_ERROR);
-	*stdout_copy = x_dup(STDOUT_FILENO);
-	if (*stdout_copy == DUP_ERROR)
-		return (PROCESS_ERROR);
-	return (SUCCESS);
-}
-*/
 t_result	restore_stdio_fd(int stdin_copy, int stdout_copy)
 {
-	if (stdin_copy != STDIO_COPY_INIT)
+	if (stdin_copy != IN_FD_INIT)
 	{
+		ft_dprintf(2, "   stdin close\n");
 		if (x_close(STDIN_FILENO) == CLOSE_ERROR)
 			return (PROCESS_ERROR);
 		if (x_dup2(stdin_copy, STDIN_FILENO) == DUP_ERROR)
@@ -66,8 +50,9 @@ t_result	restore_stdio_fd(int stdin_copy, int stdout_copy)
 		if (x_close(stdin_copy) == CLOSE_ERROR)
 			return (PROCESS_ERROR);
 	}
-	if (stdout_copy != STDIO_COPY_INIT)
+	if (stdout_copy != OUT_FD_INIT)
 	{
+		ft_dprintf(2, " stdout close\n");
 		if (x_close(STDOUT_FILENO) == CLOSE_ERROR)
 			return (PROCESS_ERROR);
 		if (x_dup2(stdout_copy, STDOUT_FILENO) == DUP_ERROR)

--- a/srcs/exec/child_process.c
+++ b/srcs/exec/child_process.c
@@ -47,12 +47,12 @@ static uint8_t	execute_command_in_child(t_ast *self_node, t_context *context)
 }
 
 // if execve erorr, no need for auto perror.
-void	child_process(t_ast *self_node, t_context *context)
+void	child_process(t_ast *self_node, t_context *context, t_result redirect_result)
 {
 	uint8_t	status;
 
-	// debug_func(__func__, __LINE__);
-	// debug_2d_array(argv);
+	if (redirect_result != SUCCESS)
+		exit (context->status);
 	if (handle_child_pipes(self_node) == PROCESS_ERROR)
 		exit(EXIT_FAILURE);
 	status = execute_command_in_child(self_node, context);

--- a/srcs/exec/exec.c
+++ b/srcs/exec/exec.c
@@ -17,30 +17,18 @@ static t_result	close_fd_for_redirect_failed(t_ast *self_node)
 	return (SUCCESS);
 }
 
-static bool	is_node_executable(t_ast *ast_node)
+// self_node != NULL
+static bool	is_node_executable(t_ast *self_node)
 {
-	t_node_kind	kind;
+	const t_node_kind	kind = self_node->kind;
 
-	if (!ast_node)
-		return (false);
-	kind = ast_node->kind;
 	return (kind == NODE_KIND_COMMAND || kind == NODE_KIND_SUBSHELL);
 }
 
-// execute_single_builtin() not return t_result
-static t_result	execute_command_internal(t_ast *self_node, t_context *context)
+static t_result	execute_builtin_or_external_command(t_ast *self_node, t_context *context)
 {
 	t_result	result;
 
-	if (expand_variable_of_cmd_tokens(self_node, context) == PROCESS_ERROR)
-		return (PROCESS_ERROR);
-	result = redirect_fd(self_node, context);
-	if ((result == PROCESS_ERROR) || (result == FAILURE))
-	{
-		if (close_fd_for_redirect_failed(self_node) == PROCESS_ERROR)
-			return (PROCESS_ERROR);
-		return (result);
-	}
 	if (is_single_builtin_command(self_node))
 		execute_single_builtin(self_node, context);
 	else if (is_node_executable(self_node))
@@ -52,11 +40,39 @@ static t_result	execute_command_internal(t_ast *self_node, t_context *context)
 	return (SUCCESS);
 }
 
-t_result	execute_command_recursive(t_ast *self_node, t_context *context)
+// execute_single_builtin() not return t_result
+static t_result	execute_command_internal(t_ast *self_node, t_context *context)
 {
 	t_result	result;
 	int			stdin_copy;
 	int			stdout_copy;
+
+	if (backup_stdio_fd(&stdin_copy, &stdout_copy, self_node) == PROCESS_ERROR)
+		return (PROCESS_ERROR);
+	result = execute_builtin_or_external_command(self_node, context);
+	if (restore_stdio_fd(stdin_copy, stdout_copy) == PROCESS_ERROR)
+		return (PROCESS_ERROR);
+	return (result);
+}
+
+static t_result	expand_and_redirect(t_ast *self_node, t_context *context)
+{
+	t_result	result;
+
+	if (expand_variable_of_cmd_tokens(self_node, context) == PROCESS_ERROR)
+		return (PROCESS_ERROR);
+	result = redirect_fd(self_node, context);
+	if ((result == PROCESS_ERROR) || (result == FAILURE))
+	{
+		if (close_fd_for_redirect_failed(self_node) == PROCESS_ERROR)
+			return (PROCESS_ERROR);
+	}
+	return (result);
+}
+
+t_result	execute_command_recursive(t_ast *self_node, t_context *context)
+{
+	t_result	result;
 
 	if (!self_node)
 		return (SUCCESS);
@@ -64,12 +80,12 @@ t_result	execute_command_recursive(t_ast *self_node, t_context *context)
 		return (PROCESS_ERROR);
 	if (exec_handle_right_node(self_node, context) == PROCESS_ERROR)
 		return (PROCESS_ERROR);
-	if (copy_stdio_fd(&stdin_copy, &stdout_copy, self_node) == PROCESS_ERROR)
+	result = expand_and_redirect(self_node, context);
+	if ((result == PROCESS_ERROR) || (result == FAILURE))
+		return (result);
+	if (execute_command_internal(self_node, context) == PROCESS_ERROR)
 		return (PROCESS_ERROR);
-	result = execute_command_internal(self_node, context);
-	if (restore_stdio_fd(stdin_copy, stdout_copy) == PROCESS_ERROR)
-		return (PROCESS_ERROR);
-	return (result);
+	return (SUCCESS);
 }
 
 t_result	execute_command(t_ast **self_node, \

--- a/srcs/exec/exec_command.c
+++ b/srcs/exec/exec_command.c
@@ -37,7 +37,7 @@ bool	is_last_command_node(t_ast *self_node)
 }
 
 // !single builtin commands, &&, ||, |, ()
-t_result	exec_command_each(t_ast *self_node, t_context *context)
+t_result	exec_command_each(t_ast *self_node, t_context *context, t_result redirect_result)
 {
 	// no need new pipe, when parent is subshell node (ittan ignore builtin..)
 	if (self_node->parent && self_node->parent->kind == NODE_KIND_OP_PIPE)
@@ -51,7 +51,7 @@ t_result	exec_command_each(t_ast *self_node, t_context *context)
 	if (self_node->pid == CHILD_PID)
 	{
 		context->is_interactive = false;
-		child_process(self_node, context);
+		child_process(self_node, context, redirect_result);
 	}
 	else
 	{

--- a/srcs/exec/redirect_connect_to_proc.c
+++ b/srcs/exec/redirect_connect_to_proc.c
@@ -32,9 +32,19 @@ static t_result	connect_redirect_out_to_proc(int out_fd)
 	return (SUCCESS);
 }
 
+bool	is_use_redirect_in(int proc_in_fd)
+{
+	return (proc_in_fd != IN_FD_INIT);
+}
+
+bool	is_use_redirect_out(int proc_out_fd)
+{
+	return (proc_out_fd != OUT_FD_INIT);
+}
+
 t_result	connect_redirect_to_proc(t_ast *self_node)
 {
-	if (self_node->proc_fd[IN] != IN_FD_INIT)
+	if (is_use_redirect_in(self_node->proc_fd[IN]))
 	{
 		if (connect_redirect_in_to_proc(\
 			&self_node->prev_fd, self_node->proc_fd[IN]) == PROCESS_ERROR)
@@ -42,8 +52,9 @@ t_result	connect_redirect_to_proc(t_ast *self_node)
 			close_proc_out_fd(&self_node->proc_fd[OUT]);
 			return (PROCESS_ERROR);
 		}
+//		self_node->proc_fd[IN] = REDIRECT_USED;
 	}
-	if (self_node->proc_fd[OUT] != OUT_FD_INIT)
+	if (is_use_redirect_out(self_node->proc_fd[OUT]))
 	{
 		if (connect_redirect_out_to_proc(\
 			self_node->proc_fd[OUT]) == PROCESS_ERROR)
@@ -51,6 +62,7 @@ t_result	connect_redirect_to_proc(t_ast *self_node)
 			close_proc_in_fd(&self_node->proc_fd[IN]);
 			return (PROCESS_ERROR);
 		}
+//		self_node->proc_fd[OUT] = REDIRECT_USED;
 	}
 	return (SUCCESS);
 }

--- a/srcs/exec/redirect_open_fd.c
+++ b/srcs/exec/redirect_open_fd.c
@@ -7,6 +7,7 @@
 #include "ms_parse.h"
 #include "ft_deque.h"
 #include "ft_sys.h"
+#include "ft_string.h"
 
 static int	open_redirect_fd(const char *path, \
 								t_open_flag open_flag, \
@@ -15,6 +16,11 @@ static int	open_redirect_fd(const char *path, \
 	int	open_fd;
 
 	errno = 0;
+	*tmp_err = 0;
+	if (ft_streq(path, DEV_STDIN_PATH))
+		return (STDIN_FILENO);
+	if (ft_streq(path, DEV_STDOUT_PATH))
+		return (STDOUT_FILENO);
 	if (open_flag == OPEN_FOR_IN)
 		open_fd = open(path, open_flag);
 	else

--- a/srcs/exec/redirects.c
+++ b/srcs/exec/redirects.c
@@ -8,6 +8,12 @@
 #include "ft_string.h"
 #include "ft_sys.h"
 
+static void	assign_failure_fd_to_proc_fd(int proc_fd[2])
+{
+	proc_fd[IN] = REDIRECT_FAILURE;
+	proc_fd[OUT] = REDIRECT_FAILURE;
+}
+
 static t_result	exec_redirect_each(t_redirect *redirect, \
 									int proc_fd[2], \
 									t_context *context)
@@ -31,6 +37,7 @@ static t_result	exec_redirect_each(t_redirect *redirect, \
 //    [redirect_symbol]-[file]-[file]    : splitted $var
 
 // redirect_list != NULL
+// if redirect failure, proc_fd[IN/OUT] = (-1)
 static t_result	expand_and_exec_redirect_all(t_ast *self_node, \
 												t_context *context)
 {
@@ -44,25 +51,31 @@ static t_result	expand_and_exec_redirect_all(t_ast *self_node, \
 		redirect = (t_redirect *)node->content;
 		result = expand_for_redirect(redirect, context);
 		if (result == FAILURE || result == PROCESS_ERROR)
+		{
+			assign_failure_fd_to_proc_fd(self_node->proc_fd);
 			return (result);
+		}
 		result = exec_redirect_each(node->content, self_node->proc_fd, context);
 		if (result == FAILURE || result == PROCESS_ERROR)
+		{
+			assign_failure_fd_to_proc_fd(self_node->proc_fd);
 			return (result);
+		}
 		node = node->next;
 	}
 	return (SUCCESS);
 }
 
-t_result	close_prod_fd_for_exit_command(t_ast *self_node)
+t_result	close_prod_fd_for_exit_command(int proc_fd[2])
 {
-	if (self_node->proc_fd[IN] != IN_FD_INIT)
+	if (proc_fd[IN] != IN_FD_INIT && proc_fd[IN] != REDIRECT_FAILURE)
 	{
-		if (x_close(self_node->proc_fd[IN]) == PROCESS_ERROR)
+		if (x_close(proc_fd[IN]) == PROCESS_ERROR)
 			return (PROCESS_ERROR);
 	}
-	if (self_node->proc_fd[OUT] != OUT_FD_INIT)
+	if (proc_fd[OUT] != OUT_FD_INIT && proc_fd[OUT] != REDIRECT_FAILURE)
 	{
-		if (x_close(self_node->proc_fd[OUT]) == PROCESS_ERROR)
+		if (x_close(proc_fd[OUT]) == PROCESS_ERROR)
 			return (PROCESS_ERROR);
 	}
 	return (SUCCESS);
@@ -80,11 +93,11 @@ t_result	redirect_fd(t_ast *self_node, t_context *context)
 		return (result);
 	if (ft_streq(command, CMD_EXIT))
 	{
-		if (close_prod_fd_for_exit_command(self_node) == PROCESS_ERROR)
+		if (close_prod_fd_for_exit_command(self_node->proc_fd) == PROCESS_ERROR)
 			return (PROCESS_ERROR);
 		return (SUCCESS);
 	}
-	result = connect_redirect_to_proc(self_node);
+	result = connect_redirect_to_proc(&self_node->prev_fd, self_node->proc_fd);
 	if (result == PROCESS_ERROR)
 		return (PROCESS_ERROR);
 	return (SUCCESS);

--- a/srcs/exec/single_builtin.c
+++ b/srcs/exec/single_builtin.c
@@ -34,10 +34,12 @@ bool	is_single_builtin_command(const t_ast *self_node)
 	return (true);
 }
 
-void	execute_single_builtin(t_ast *self_node, t_context *context)
+void	execute_single_builtin(t_ast *self_node, t_context *context, t_result redirect_result)
 {
 	char	**argv;
 
+	if (redirect_result != SUCCESS)
+		return ;
 	argv = convert_command_to_argv(self_node->command);
 	context->status = call_builtin_command((const char *const *)argv, context);
 	free_2d_array(&argv);

--- a/test/integration_test/run_redirects.py
+++ b/test/integration_test/run_redirects.py
@@ -19,6 +19,7 @@ def main():
                     "nosuchfile < && nosuchfile1 <",
                     "nosuchfile < && < nosuchfile1",
                     "< nosuchfile && < nosuchfile1 < nosuchfile2",
+                    "cat -e < /dev/stdin\naaa\nbbb\nccc"
                     ] # todo more test
 
     redirects_out_error_test = [
@@ -35,6 +36,9 @@ def main():
                     # "nosuchfile > && nosuchfile1 >",
                     # "nosuchfile > && > nosuchfile1",
                     # "> nosuchfile && > nosuchfile1 > nosuchfile2",
+                    "echo hello >/dev/stdout",
+                    "echo hello >/dev/stdout | cat -e",
+                    "echo hello </dev/stdin | cat >/dev/stdout | cat -e"
                     ] # todo more test
 
     redirects_in_test =[

--- a/test/integration_test/run_redirects.py
+++ b/test/integration_test/run_redirects.py
@@ -97,17 +97,17 @@ def main():
     redirects_heredoc_test = [
         "cat << eof \ntest1\ntest2\n$HOME\n\"$HOME\"\n'$HOME'\neof",
         "cat <<eof1<<eof2\neof11\neof\neof1\neof22\n$HOME$hoge$PWD\neof2\n",
-        "rm -f out1 out2\ncat << eof>out1>out2 \ntest1\ntest2\n$HOME\n\"$HOME\"\n'$HOME'\neof\ncat out1\ncatou2\nrm -f out1 out2",
+        "rm -f out1 out2\ncat << eof>out1>out2 \ntest1\ntest2\n$HOME\n\"$HOME\"\n'$HOME'\neof\ncat out1\ncat out2\nrm -f out1 out2",
         "cat -e << 'eof' \ntest1\ntest2\n$HOME\n\"$HOME\"\n'$HOME'\neof",
         "cat -e << '' \ntest1\ntest2\n$HOME\n\"$HOME\"\n'$HOME'\n\n",
         "cat -e << \"\" \ntest1\ntest2\n$HOME\n\"$HOME\"\n'$HOME'\n\n",
-        "cat << $HOME \ntest1\ntest2\n$HOME\n\"$HOME\"\n'$HOME'\n$HOME",
-        "cat << '$HOME' \ntest1\ntest2\n$HOME\n\"$HOME\"\n'$HOME'\n$HOME",
-        "cat << \"$HOME\" \ntest1\ntest2\n$HOME\n\"$HOME\"\n'$HOME'\n$HOME$USER$hoge $huga$PWD",
+        "cat << $HOME \ntest1\ntest2\n$HOMEee\n\"$HOME\"\n'$HOME'\n$HOME",
+        "cat << '$HOME' \ntest1\ntest2\n$HOMEee\n\"$HOME\"\n'$HOME'\n$HOME",
+        "cat << \"$HOME\" \ntest1\ntest2\n$HOMEee\n\"$HOME\"\n'$HOME'\n$HOME$USER$hoge $huga$PWD\n$HOME",
         "cat << $nothing \ntest1\n\ntest2\n$HOME\n\"$HOME\"\n'$HOME'\n$nothing",
         "cat -e << 'e'o\"f\" \ntest1\n\ntest2\n$?$HOME$?\n\"$HOME\"\n'$HOME'\neof",
         "cat << a\n$HOME\"\"\n\n        '$hoge'$hoge\n '\n\"\na",
-        f"cat << eof\n{BIG}\neof\n | wc",
+        f"cat << eof | wc \n{BIG}\neof\n",
         ]  # todo more test
 
     test_res |= test("redirect_in_error", redirects_in_error_test, False)

--- a/test/integration_test/test_function/test_functions.py
+++ b/test/integration_test/test_function/test_functions.py
@@ -56,13 +56,17 @@ def save_ko_cmd(test_name, out_ko_case, val_ko_case):
     with open(f'ko_case_{test_name}_cmd.txt', 'w') as f:
         if len(out_ko_case):
             f.write(f'[OUTPUT KO CASE OF : {test_name}]\n')
+            f.write(f'{"-" * 100}\n')
             for stdin, _, _ in out_ko_case:
                 f.write(f'{stdin}\n')
+                f.write(f'{"-" * 100}\n')
 
         if len(val_ko_case):
             f.write(f'[LEAK or FD KO CASE OF : {test_name}]\n')
+            f.write(f'{"-" * 100}\n')
             for ko in val_ko_case:
                 f.write(f'{ko}\n')
+                f.write(f'{"-" * 100}\n')
             # for stdin, _, _ in val_ko_case:
             #     f.write(f'{stdin}\n')
 
@@ -94,6 +98,7 @@ def save_ko_out(test_name, out_ko_case, val_ko_case):
     with open(f'ko_case_{test_name}_out.txt', 'w') as f:
         if len(out_ko_case):
             f.write(f'[OUTPUT KO CASE OF : {test_name}]\n')
+            f.write(f'{"-" * 100}\n')
             for ko in out_ko_case:
                 stdin, m_res, b_res = ko
                 write_out_to_file("minishell", stdin, m_res, f)
@@ -102,9 +107,10 @@ def save_ko_out(test_name, out_ko_case, val_ko_case):
 
         if len(val_ko_case):
             f.write(f'[LEAK or FD KO CASE OF : {test_name}]\n')
-
+            f.write(f'{"-" * 100}\n')
             for ko in val_ko_case:
                 f.write(ko)
+                f.write(f'{"-" * 100}\n')
                 # stdin, m_res, b_res = ko
                 # write_val_to_f("minishell", stdin, m_res, f)
                 # write_val_to_f("bash", stdin, b_res, f)
@@ -132,13 +138,17 @@ def print_ko_case(test_name, test_res, out_ko_case, val_ko_case):
 
     if len(out_ko_case):
         print(f'[OUTPUT KO CASE OF : {test_name}]')
+        print('-' * 100)
         for stdin, _, _ in out_ko_case:
             print(stdin)
+            print('-' * 100)
 
     if len(val_ko_case):
         print(f'[LEAK or FD KO CASE OF : {test_name}]')
+        print('-' * 100)
         for ko in val_ko_case:
             print(ko)
+            print('-' * 100)
     #     for stdin, _, _ in val_ko_case:
     #         print(stdin)
 


### PR DESCRIPTION
- [x] redirect fileに`/dev/stdin, out`が指定された際の挙動を修正 f2b8d99
  - open(/dev/stdout) で fd=3を取得していた。pipeに繋がっていないfd=3（実質stdout）に書き込んでおり、以下の挙動に。
  - pathが`/dev/stdin`, `/dev/stdout`であればopenせずに`STDIN_FILENO`, `STDOUT_FILENO`を渡すことでstdin, outが複製されないようにした。これで良いのか自信はない...
  ```shell
  # minishell
  minishell echo hello>/dev/stdout | echo world | cat -e
  hello
  world$
  
  # bash
  $ echo hello >/dev/stdout | echo world | cat -e
  world$
  ```
- [x] ~refactor: close(proc_fd)でinitial valueで埋めるよう変更 039f565~ バグ取れないのでやめる
  -  ~bug : close(fd)で初期化したせいでstdin/outのclose判定が回っておらず、input file is output fileになっている~
- [ ] bug : `< redirect_error | cat`などがバグっていそう（dev）
  - redirect errorでpipeの次のcatへstdinを渡しているため、入力待ちになっている 
  - 入力がないことを伝えたいが、catへのprev_fd = -1 だとdup, close, catでエラー、close(stdin)でcat のエラーが発生
  - redirect failureとなるprocはchild procまで実行しexitした方が良さそう...? pipe_fdが自動で閉じられるので、catが勝手に終了することを期待
  - redirectが失敗した情報をコマンド実行部分まで運ぶの点が微妙すぎる...