### PR TITLE
Update redirect use /dev/stdin, /dev/stdout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -251,82 +251,97 @@ t		: all
 # test all
 .PHONY		: test_all
 test_all	: all
-	$(shell rm ko_case_*.txt)
+	rm -f ko_case_*.txt
 	python3 ./test/integration_test/run_all.py
 
 # test multi pipe
 .PHONY		: test_pipe
 test_pipe	: all
+	rm -f ko_case_*.txt
 	python3 ./test/integration_test/run_pipe.py
 
 # test builtin cd
 .PHONY		: test_cd
 test_cd		: all
+	rm -f ko_case_*.txt
 	python3 ./test/integration_test/run_cd.py
 
 # test builtin declare
 .PHONY			: test_declare
 test_declare	: all
+	rm -f ko_case_*.txt
 	python3 ./test/integration_test/run_declare.py
 
 # test builtin echo
 .PHONY		: test_echo
 test_echo	: all
+	rm -f ko_case_*.txt
 	python3 ./test/integration_test/run_echo.py
 
 # test builtin exit
 .PHONY		: test_exit
 test_exit	: all
+	rm -f ko_case_*.txt
 	python3 ./test/integration_test/run_exit.py
 
 # test builtin export
 .PHONY		: test_export
 test_export	: all
+	rm -f ko_case_*.txt
 	python3 ./test/integration_test/run_export.py
 
 # test builtin pwd
 .PHONY		: test_pwd
 test_pwd	: all
+	rm -f ko_case_*.txt
 	python3 ./test/integration_test/run_pwd.py
 
 # test op paren
 .PHONY		: test_paren
 test_paren	: all
+	rm -f ko_case_*.txt
 	python3 ./test/integration_test/run_paren.py
 
 # test op and or
 .PHONY		: test_and_or
 test_and_or	: all
+	rm -f ko_case_*.txt
 	python3 ./test/integration_test/run_and_or.py
 
 # test mix
 .PHONY		: test_mix
 test_mix	: all
+	rm -f ko_case_*.txt
 	python3 ./test/integration_test/run_mix.py
 
 # test redirects
 .PHONY		: test_redirects
 test_redirects	: all
+	rm -f ko_case_*.txt
 	python3 ./test/integration_test/run_redirects.py
 
 # test error
 .PHONY		: test_error
 test_error	: all
+	rm -f ko_case_*.txt
 	python3 ./test/integration_test/run_error.py
 
 # test env
 .PHONY		: test_env
 test_env	: all
+	rm -f ko_case_*.txt
 	python3 ./test/integration_test/run_env.py
 
 # test expansion
 .PHONY		: test_expansion
 test_expansion	: all
+	rm -f ko_case_*.txt
 	python3 ./test/integration_test/run_expansion.py
 
 # test original
 .PHONY		: test_original
 test_original	: all
+	rm -f ko_case_*.txt
 	python3 ./test/integration_test/run_original.py
 
 

--- a/Makefile
+++ b/Makefile
@@ -102,6 +102,7 @@ SRCS		+=	$(EXEC_DIR)/$(EXPAND_DIR)/concat_tokens.c  \
 				$(EXEC_DIR)/call_builtin_command.c \
 				$(EXEC_DIR)/child_pipes.c \
 				$(EXEC_DIR)/child_process.c \
+				$(EXEC_DIR)/close_proc_fds.c \
 				$(EXEC_DIR)/exec.c \
 				$(EXEC_DIR)/exec_command.c \
 				$(EXEC_DIR)/exec_external_command.c \

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -62,7 +62,6 @@
 /* parse, exec */
 # define IN_FD_INIT			STDIN_FILENO
 # define OUT_FD_INIT		STDOUT_FILENO
-# define REDIRECT_FAILURE	(-1)
 
 /* utils */
 # define RANDOM_FILENAME	"/dev/urandom"

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -60,8 +60,9 @@
 # define ERROR_MSG_RETRIEVE_CWD	"error retrieving current directory"
 
 /* parse, exec */
-# define IN_FD_INIT		STDIN_FILENO
-# define OUT_FD_INIT	STDOUT_FILENO
+# define IN_FD_INIT			STDIN_FILENO
+# define OUT_FD_INIT		STDOUT_FILENO
+# define REDIRECT_FAILURE	(1)
 
 /* utils */
 # define RANDOM_FILENAME	"/dev/urandom"

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -62,7 +62,7 @@
 /* parse, exec */
 # define IN_FD_INIT			STDIN_FILENO
 # define OUT_FD_INIT		STDOUT_FILENO
-# define REDIRECT_FAILURE	(1)
+# define REDIRECT_FAILURE	(-1)
 
 /* utils */
 # define RANDOM_FILENAME	"/dev/urandom"

--- a/includes/ms_exec.h
+++ b/includes/ms_exec.h
@@ -72,17 +72,11 @@ bool			is_command_builtin(const char *cmd);
 /* ast */
 char			**convert_command_to_argv(t_deque *command);
 t_result		handle_child_pipes(t_ast *self_node);
-void			child_process(t_ast *self_node, \
-								t_context *context, \
-								t_result redirect_result);
+void			child_process(t_ast *self_node, t_context *context);
 t_result		handle_parent_pipes(t_ast *self_node);
 t_result		parent_process(t_ast *self_node, t_context *context);
-t_result		exec_command_each(t_ast *self_node, \
-									t_context *context, \
-									t_result redirect_result);
-void			execute_single_builtin(t_ast *self_node, \
-										t_context *context, \
-										t_result redirect_result);
+t_result		exec_command_each(t_ast *self_node, t_context *context);
+t_result		execute_single_builtin(t_ast *self_node, t_context *context);
 bool			is_single_builtin_command(const t_ast *self_node);
 bool			is_last_command_node(t_ast *self_node);
 char			*get_head_token_str(const t_deque *command);

--- a/includes/ms_exec.h
+++ b/includes/ms_exec.h
@@ -72,11 +72,17 @@ bool			is_command_builtin(const char *cmd);
 /* ast */
 char			**convert_command_to_argv(t_deque *command);
 t_result		handle_child_pipes(t_ast *self_node);
-void			child_process(t_ast *self_node, t_context *context, t_result redirect_result);
+void			child_process(t_ast *self_node, \
+								t_context *context, \
+								t_result redirect_result);
 t_result		handle_parent_pipes(t_ast *self_node);
 t_result		parent_process(t_ast *self_node, t_context *context);
-t_result		exec_command_each(t_ast *self_node, t_context *context, t_result redirect_result);
-void			execute_single_builtin(t_ast *self_node, t_context *context, t_result redirect_result);
+t_result		exec_command_each(t_ast *self_node, \
+									t_context *context, \
+									t_result redirect_result);
+void			execute_single_builtin(t_ast *self_node, \
+										t_context *context, \
+										t_result redirect_result);
 bool			is_single_builtin_command(const t_ast *self_node);
 bool			is_last_command_node(t_ast *self_node);
 char			*get_head_token_str(const t_deque *command);

--- a/includes/ms_exec.h
+++ b/includes/ms_exec.h
@@ -21,6 +21,9 @@
 # define STATUS_CMD_NOT_FOUND		127
 # define REDIRECT_ONLY_SUCCESS		0
 
+# define DEV_STDIN_PATH		"/dev/stdin"
+# define DEV_STDOUT_PATH	"/dev/stdout"
+
 # define STDIO_COPY_INIT	(-1)
 
 # define ERROR_MSG_NO_SUCH_FILE			"No such file or directory"

--- a/includes/ms_exec.h
+++ b/includes/ms_exec.h
@@ -98,5 +98,7 @@ t_result		open_redirect_fd_and_save_to_proc(t_redirect *redirect, \
 													int *open_errno);
 t_result		close_proc_in_fd(int *proc_in_fd);
 t_result		close_proc_out_fd(int *proc_out_fd);
+bool			is_use_redirect_in(int proc_in_fd);
+bool			is_use_redirect_out(int proc_out_fd);
 
 #endif //MS_EXEC_H

--- a/includes/ms_exec.h
+++ b/includes/ms_exec.h
@@ -72,11 +72,11 @@ bool			is_command_builtin(const char *cmd);
 /* ast */
 char			**convert_command_to_argv(t_deque *command);
 t_result		handle_child_pipes(t_ast *self_node);
-void			child_process(t_ast *self_node, t_context *context);
+void			child_process(t_ast *self_node, t_context *context, t_result redirect_result);
 t_result		handle_parent_pipes(t_ast *self_node);
 t_result		parent_process(t_ast *self_node, t_context *context);
-t_result		exec_command_each(t_ast *self_node, t_context *context);
-void			execute_single_builtin(t_ast *self_node, t_context *context);
+t_result		exec_command_each(t_ast *self_node, t_context *context, t_result redirect_result);
+void			execute_single_builtin(t_ast *self_node, t_context *context, t_result redirect_result);
 bool			is_single_builtin_command(const t_ast *self_node);
 bool			is_last_command_node(t_ast *self_node);
 char			*get_head_token_str(const t_deque *command);

--- a/includes/ms_exec.h
+++ b/includes/ms_exec.h
@@ -92,7 +92,7 @@ t_result		exec_handle_right_node(t_ast *self_node, t_context *context);
 t_redirect		*init_redirect(void);
 void			del_redirect(void *content);
 t_result		redirect_fd(t_ast *self_node, t_context *context);
-t_result		connect_redirect_to_proc(t_ast *self_node);
+t_result		connect_redirect_to_proc(int *prev_fd, int proc_fd[2]);
 t_result		open_redirect_fd_and_save_to_proc(t_redirect *redirect, \
 													int proc_fd[2], \
 													int *open_errno);

--- a/includes/ms_exec.h
+++ b/includes/ms_exec.h
@@ -58,7 +58,7 @@ t_result		execute_command(t_ast **self_node, \
 								t_context *context, \
 								t_result heredoc_result);
 t_result		execute_command_recursive(t_ast *self_node, t_context *context);
-t_result		copy_stdio_fd(int *stdin_copy, \
+t_result		backup_stdio_fd(int *stdin_copy, \
 								int *stdout_copy, \
 								const t_ast *self_node);
 t_result		restore_stdio_fd(int stdin_copy, int stdout_copy);

--- a/includes/ms_expansion.h
+++ b/includes/ms_expansion.h
@@ -43,9 +43,10 @@ t_result	open_current_directory(DIR **dirp);
 t_result	get_next_dirp_in_current(DIR *dirp, struct dirent **dirent);
 t_result	close_current_directory(DIR *dirp);
 void		sort_filenames(t_deque *tokens);
-t_result	expand_for_heredoc(t_redirect *redirect, t_context *context);
+t_result	expand_for_heredoc(t_ast *self_node, t_context *context);
 t_result	expand_variables_in_heredoc(t_redirect *redirect, \
 										t_context *context);
-t_result	expand_for_redirect(t_redirect *redirect, \
-									t_context *context);
+t_result	expand_for_filename(t_ast *self_node, t_context *context);
+void		assign_failure_fd_to_proc_fds(int proc_fd[2]);
+
 #endif //MS_EXPANSION_H

--- a/srcs/exec/backup_fd.c
+++ b/srcs/exec/backup_fd.c
@@ -6,7 +6,7 @@
 #include "ft_string.h"
 #include "ft_sys.h"
 
-t_result	copy_stdio_fd(int *stdin_copy, \
+t_result	backup_stdio_fd(int *stdin_copy, \
 							int *stdout_copy, \
 							const t_ast *self_node)
 {

--- a/srcs/exec/backup_fd.c
+++ b/srcs/exec/backup_fd.c
@@ -11,6 +11,7 @@ static bool	is_command_not_used_redirect(const char *command)
 	return (ft_streq(command, CMD_EXIT));
 }
 
+// can't use is_use_redirect_in/out..., causes input file is output file...??
 t_result	backup_stdio_fd(int *stdin_copy, \
 							int *stdout_copy, \
 							const t_ast *self_node)

--- a/srcs/exec/backup_fd.c
+++ b/srcs/exec/backup_fd.c
@@ -6,6 +6,11 @@
 #include "ft_string.h"
 #include "ft_sys.h"
 
+static bool	is_command_not_used_redirect(const char *command)
+{
+	return (ft_streq(command, CMD_EXIT));
+}
+
 t_result	backup_stdio_fd(int *stdin_copy, \
 							int *stdout_copy, \
 							const t_ast *self_node)
@@ -14,7 +19,7 @@ t_result	backup_stdio_fd(int *stdin_copy, \
 
 	*stdin_copy = IN_FD_INIT;
 	*stdout_copy = OUT_FD_INIT;
-	if (ft_streq(command, CMD_EXIT))
+	if (is_command_not_used_redirect(command))
 		return (SUCCESS);
 	*stdin_copy = x_dup(STDIN_FILENO);
 	if (*stdin_copy == DUP_ERROR)

--- a/srcs/exec/child_process.c
+++ b/srcs/exec/child_process.c
@@ -4,8 +4,6 @@
 #include "ms_parse.h"
 #include "ms_builtin.h"
 #include "ft_deque.h"
-#include "ft_dprintf.h"
-#include "ft_string.h"
 #include "ft_mem.h"
 
 static uint8_t	execute_builtin_command(const char *const *argv, \
@@ -54,8 +52,10 @@ void	child_process(t_ast *self_node, t_context *context)
 	t_result	redirect_result;
 
 	redirect_result = redirect_fd(self_node, context);
-	if (redirect_result == FAILURE || redirect_result == PROCESS_ERROR)
+	if (redirect_result == FAILURE)
 		exit(context->status);
+	if (redirect_result == PROCESS_ERROR)
+		exit(EXIT_FAILURE);
 	if (handle_child_pipes(self_node) == PROCESS_ERROR)
 		exit(EXIT_FAILURE);
 	status = execute_command_in_child(self_node, context);

--- a/srcs/exec/child_process.c
+++ b/srcs/exec/child_process.c
@@ -46,14 +46,15 @@ static uint8_t	execute_command_in_child(t_ast *self_node, t_context *context)
 	return (status);
 }
 
+//todo:can't return proc error
 // if execve erorr, no need for auto perror.
-void	child_process(t_ast *self_node, \
-						t_context *context, \
-						t_result redirect_result)
+void	child_process(t_ast *self_node, t_context *context)
 {
-	uint8_t	status;
+	uint8_t		status;
+	t_result	redirect_result;
 
-	if (redirect_result == FAILURE)
+	redirect_result = redirect_fd(self_node, context);
+	if (redirect_result == FAILURE || redirect_result == PROCESS_ERROR)
 		exit(context->status);
 	if (handle_child_pipes(self_node) == PROCESS_ERROR)
 		exit(EXIT_FAILURE);

--- a/srcs/exec/child_process.c
+++ b/srcs/exec/child_process.c
@@ -47,12 +47,12 @@ static uint8_t	execute_command_in_child(t_ast *self_node, t_context *context)
 }
 
 // if execve erorr, no need for auto perror.
-void	child_process(t_ast *self_node, t_context *context)
+void	child_process(t_ast *self_node, t_context *context, t_result redirect_result)
 {
 	uint8_t	status;
 
-	// debug_func(__func__, __LINE__);
-	// debug_2d_array(argv);
+	if (redirect_result == FAILURE)
+		exit(context->status);
 	if (handle_child_pipes(self_node) == PROCESS_ERROR)
 		exit(EXIT_FAILURE);
 	status = execute_command_in_child(self_node, context);

--- a/srcs/exec/child_process.c
+++ b/srcs/exec/child_process.c
@@ -47,7 +47,9 @@ static uint8_t	execute_command_in_child(t_ast *self_node, t_context *context)
 }
 
 // if execve erorr, no need for auto perror.
-void	child_process(t_ast *self_node, t_context *context, t_result redirect_result)
+void	child_process(t_ast *self_node, \
+						t_context *context, \
+						t_result redirect_result)
 {
 	uint8_t	status;
 

--- a/srcs/exec/close_proc_fds.c
+++ b/srcs/exec/close_proc_fds.c
@@ -1,0 +1,25 @@
+#include "minishell.h"
+#include "ms_exec.h"
+#include "ms_tokenize.h"
+#include "ms_parse.h"
+#include "ft_sys.h"
+
+t_result	close_proc_in_fd(int *proc_in_fd)
+{
+	if (*proc_in_fd == IN_FD_INIT)
+		return (SUCCESS);
+	if (x_close(*proc_in_fd) == CLOSE_ERROR)
+		return (PROCESS_ERROR);
+	*proc_in_fd = IN_FD_INIT;
+	return (SUCCESS);
+}
+
+t_result	close_proc_out_fd(int *proc_out_fd)
+{
+	if (*proc_out_fd == OUT_FD_INIT)
+		return (SUCCESS);
+	if (x_close(*proc_out_fd) == CLOSE_ERROR)
+		return (PROCESS_ERROR);
+	*proc_out_fd = OUT_FD_INIT;
+	return (SUCCESS);
+}

--- a/srcs/exec/exec.c
+++ b/srcs/exec/exec.c
@@ -13,7 +13,8 @@ static bool	is_node_executable(t_ast *ast_node)
 }
 
 // execute_single_builtin() not return t_result
-static t_result	execute_builtin_or_external_command(t_ast *self_node, t_context *context)
+static t_result	execute_builtin_or_external_command(t_ast *self_node, \
+													t_context *context)
 {
 	t_result	redirect_result;
 
@@ -26,7 +27,8 @@ static t_result	execute_builtin_or_external_command(t_ast *self_node, t_context 
 		execute_single_builtin(self_node, context, redirect_result);
 	else if (is_node_executable(self_node))
 	{
-		if (exec_command_each(self_node, context, redirect_result) == PROCESS_ERROR)
+		if (exec_command_each(\
+				self_node, context, redirect_result) == PROCESS_ERROR)
 			return (PROCESS_ERROR);
 	}
 	return (SUCCESS);

--- a/srcs/exec/exec.c
+++ b/srcs/exec/exec.c
@@ -5,17 +5,17 @@
 #include "ms_result.h"
 #include "ft_sys.h"
 
-static t_result	close_fd_for_redirect_failed(t_ast *self_node)
-{
-	if (self_node->prev_fd != IN_FD_INIT)
-	{
-		if (x_close(self_node->prev_fd) == CLOSE_ERROR)
-			return (PROCESS_ERROR);
-	}
-	if (self_node->parent)
-		self_node->parent->prev_fd = IN_FD_INIT;
-	return (SUCCESS);
-}
+//static t_result	close_fd_for_redirect_failed(t_ast *self_node)
+//{
+//	if (self_node->prev_fd != IN_FD_INIT)
+//	{
+//		if (x_close(self_node->prev_fd) == CLOSE_ERROR)
+//			return (PROCESS_ERROR);
+//	}
+//	if (self_node->parent)
+//		self_node->parent->prev_fd = IN_FD_INIT;
+//	return (SUCCESS);
+//}
 
 static bool	is_node_executable(t_ast *ast_node)
 {
@@ -27,23 +27,24 @@ static bool	is_node_executable(t_ast *ast_node)
 // execute_single_builtin() not return t_result
 static t_result	execute_builtin_or_external_command(t_ast *self_node, t_context *context)
 {
-	t_result	result;
+	t_result	redirect_result;
 
 	if (expand_variable_of_cmd_tokens(self_node, context) == PROCESS_ERROR)
 		return (PROCESS_ERROR);
-	result = redirect_fd(self_node, context);
-	if ((result == PROCESS_ERROR) || (result == FAILURE))
-	{
-		if (close_fd_for_redirect_failed(self_node) == PROCESS_ERROR)
-			return (PROCESS_ERROR);
-		return (result);
-	}
+	redirect_result = redirect_fd(self_node, context);
+	if (redirect_result == PROCESS_ERROR)
+		return (PROCESS_ERROR);
+//	if ((redirect_result == PROCESS_ERROR) || (redirect_result == FAILURE))
+//	{
+//		if (close_fd_for_redirect_failed(self_node) == PROCESS_ERROR)
+//			return (PROCESS_ERROR);
+//		return (redirect_result);
+//	}
 	if (is_single_builtin_command(self_node))
-		execute_single_builtin(self_node, context);
+		execute_single_builtin(self_node, context, redirect_result);
 	else if (is_node_executable(self_node))
 	{
-		result = exec_command_each(self_node, context);
-		if (result == PROCESS_ERROR)
+		if (exec_command_each(self_node, context, redirect_result) == PROCESS_ERROR)
 			return (PROCESS_ERROR);
 	}
 	return (SUCCESS);

--- a/srcs/exec/exec.c
+++ b/srcs/exec/exec.c
@@ -56,7 +56,7 @@ t_result	execute_command_internal(t_ast *self_node, t_context *context)
 	int			stdin_copy;
 	int			stdout_copy;
 
-	if (copy_stdio_fd(&stdin_copy, &stdout_copy, self_node) == PROCESS_ERROR)
+	if (backup_stdio_fd(&stdin_copy, &stdout_copy, self_node) == PROCESS_ERROR)
 		return (PROCESS_ERROR);
 	result = execute_builtin_or_external_command(self_node, context);
 	if (restore_stdio_fd(stdin_copy, stdout_copy) == PROCESS_ERROR)

--- a/srcs/exec/exec.c
+++ b/srcs/exec/exec.c
@@ -5,18 +5,6 @@
 #include "ms_result.h"
 #include "ft_sys.h"
 
-//static t_result	close_fd_for_redirect_failed(t_ast *self_node)
-//{
-//	if (self_node->prev_fd != IN_FD_INIT)
-//	{
-//		if (x_close(self_node->prev_fd) == CLOSE_ERROR)
-//			return (PROCESS_ERROR);
-//	}
-//	if (self_node->parent)
-//		self_node->parent->prev_fd = IN_FD_INIT;
-//	return (SUCCESS);
-//}
-
 static bool	is_node_executable(t_ast *ast_node)
 {
 	const t_node_kind	kind = ast_node->kind;
@@ -34,12 +22,6 @@ static t_result	execute_builtin_or_external_command(t_ast *self_node, t_context 
 	redirect_result = redirect_fd(self_node, context);
 	if (redirect_result == PROCESS_ERROR)
 		return (PROCESS_ERROR);
-//	if ((redirect_result == PROCESS_ERROR) || (redirect_result == FAILURE))
-//	{
-//		if (close_fd_for_redirect_failed(self_node) == PROCESS_ERROR)
-//			return (PROCESS_ERROR);
-//		return (redirect_result);
-//	}
 	if (is_single_builtin_command(self_node))
 		execute_single_builtin(self_node, context, redirect_result);
 	else if (is_node_executable(self_node))

--- a/srcs/exec/exec_command.c
+++ b/srcs/exec/exec_command.c
@@ -38,9 +38,7 @@ bool	is_last_command_node(t_ast *self_node)
 
 // !single builtin commands, &&, ||, |, ()
 // no need new pipe, when parent is subshell node (ittan ignore builtin..)
-t_result	exec_command_each(t_ast *self_node, \
-								t_context *context, \
-								t_result redirect_result)
+t_result	exec_command_each(t_ast *self_node, t_context *context)
 {
 	if (self_node->parent && self_node->parent->kind == NODE_KIND_OP_PIPE)
 	{
@@ -53,7 +51,7 @@ t_result	exec_command_each(t_ast *self_node, \
 	if (self_node->pid == CHILD_PID)
 	{
 		context->is_interactive = false;
-		child_process(self_node, context, redirect_result);
+		child_process(self_node, context);
 	}
 	else
 	{

--- a/srcs/exec/exec_command.c
+++ b/srcs/exec/exec_command.c
@@ -37,7 +37,7 @@ bool	is_last_command_node(t_ast *self_node)
 }
 
 // !single builtin commands, &&, ||, |, ()
-t_result	exec_command_each(t_ast *self_node, t_context *context)
+t_result	exec_command_each(t_ast *self_node, t_context *context, t_result redirect_result)
 {
 	// no need new pipe, when parent is subshell node (ittan ignore builtin..)
 	if (self_node->parent && self_node->parent->kind == NODE_KIND_OP_PIPE)
@@ -51,7 +51,7 @@ t_result	exec_command_each(t_ast *self_node, t_context *context)
 	if (self_node->pid == CHILD_PID)
 	{
 		context->is_interactive = false;
-		child_process(self_node, context);
+		child_process(self_node, context, redirect_result);
 	}
 	else
 	{

--- a/srcs/exec/exec_command.c
+++ b/srcs/exec/exec_command.c
@@ -37,9 +37,11 @@ bool	is_last_command_node(t_ast *self_node)
 }
 
 // !single builtin commands, &&, ||, |, ()
-t_result	exec_command_each(t_ast *self_node, t_context *context, t_result redirect_result)
+// no need new pipe, when parent is subshell node (ittan ignore builtin..)
+t_result	exec_command_each(t_ast *self_node, \
+								t_context *context, \
+								t_result redirect_result)
 {
-	// no need new pipe, when parent is subshell node (ittan ignore builtin..)
 	if (self_node->parent && self_node->parent->kind == NODE_KIND_OP_PIPE)
 	{
 		if (x_pipe(self_node->pipe_fd) == PIPE_ERROR)

--- a/srcs/exec/expand/expand_for_heredoc.c
+++ b/srcs/exec/expand/expand_for_heredoc.c
@@ -14,7 +14,8 @@ static bool	is_expand_in_heredoc(t_redirect *redirect)
 }
 
 // redirect->kind is NODE_KIND_HEREDOC
-static t_result	expand_for_heredoc_each(t_redirect *redirect, t_context *context)
+static t_result	expand_for_heredoc_each(t_redirect *redirect, \
+										t_context *context)
 {
 	if (!is_expand_in_heredoc(redirect))
 		return (SUCCESS);

--- a/srcs/exec/expand/expand_for_heredoc.c
+++ b/srcs/exec/expand/expand_for_heredoc.c
@@ -14,9 +14,32 @@ static bool	is_expand_in_heredoc(t_redirect *redirect)
 }
 
 // redirect->kind is NODE_KIND_HEREDOC
-t_result	expand_for_heredoc(t_redirect *redirect, t_context *context)
+static t_result	expand_for_heredoc_each(t_redirect *redirect, t_context *context)
 {
 	if (!is_expand_in_heredoc(redirect))
 		return (SUCCESS);
 	return (expand_variables_in_heredoc(redirect, context));
+}
+
+t_result	expand_for_heredoc(t_ast *self_node, t_context *context)
+{
+	t_deque_node	*node;
+	t_redirect		*redirect;
+
+	if (!self_node->redirect_list)
+		return (SUCCESS);
+	node = self_node->redirect_list->node;
+	while (node)
+	{
+		redirect = (t_redirect *)node->content;
+		if (redirect->kind != TOKEN_KIND_REDIRECT_HEREDOC)
+		{
+			node = node->next;
+			continue ;
+		}
+		if (expand_for_heredoc_each(redirect, context) == PROCESS_ERROR)
+			return (PROCESS_ERROR);
+		node = node->next;
+	}
+	return (SUCCESS);
 }

--- a/srcs/exec/expand/expand_for_redirect.c
+++ b/srcs/exec/expand/expand_for_redirect.c
@@ -41,7 +41,6 @@ static t_result	expand_for_filename_each(t_redirect *redirect, \
 t_result	expand_for_filename(t_ast *self_node, t_context *context)
 {
 	t_deque_node	*node;
-	t_result		result;
 	t_redirect		*redirect;
 
 	node = self_node->redirect_list->node;
@@ -54,10 +53,7 @@ t_result	expand_for_filename(t_ast *self_node, t_context *context)
 			continue ;
 		}
 		if (expand_for_filename_each(redirect, context) == FAILURE)
-		{
-			assign_failure_fd_to_proc_fds(self_node->proc_fd);
 			return (FAILURE);
-		}
 		node = node->next;
 	}
 	return (SUCCESS);

--- a/srcs/exec/redirect_connect_to_proc.c
+++ b/srcs/exec/redirect_connect_to_proc.c
@@ -32,23 +32,21 @@ static t_result	connect_redirect_out_to_proc(int out_fd)
 	return (SUCCESS);
 }
 
-t_result	connect_redirect_to_proc(t_ast *self_node)
+t_result	connect_redirect_to_proc(int *prev_fd, int proc_fd[2])
 {
-	if (self_node->proc_fd[IN] != IN_FD_INIT)
+	if (proc_fd[IN] != IN_FD_INIT)
 	{
-		if (connect_redirect_in_to_proc(\
-			&self_node->prev_fd, self_node->proc_fd[IN]) == PROCESS_ERROR)
+		if (connect_redirect_in_to_proc(prev_fd, proc_fd[IN]) == PROCESS_ERROR)
 		{
-			close_proc_out_fd(&self_node->proc_fd[OUT]);
+			close_proc_out_fd(&proc_fd[OUT]);
 			return (PROCESS_ERROR);
 		}
 	}
-	if (self_node->proc_fd[OUT] != OUT_FD_INIT)
+	if (proc_fd[OUT] != OUT_FD_INIT)
 	{
-		if (connect_redirect_out_to_proc(\
-			self_node->proc_fd[OUT]) == PROCESS_ERROR)
+		if (connect_redirect_out_to_proc(proc_fd[OUT]) == PROCESS_ERROR)
 		{
-			close_proc_in_fd(&self_node->proc_fd[IN]);
+			close_proc_in_fd(&proc_fd[IN]);
 			return (PROCESS_ERROR);
 		}
 	}

--- a/srcs/exec/redirect_connect_to_proc.c
+++ b/srcs/exec/redirect_connect_to_proc.c
@@ -4,6 +4,16 @@
 #include "ft_deque.h"
 #include "ft_sys.h"
 
+bool	is_use_redirect_in(int proc_in_fd)
+{
+	return (!(proc_in_fd == IN_FD_INIT || proc_in_fd == REDIRECT_FAILURE));
+}
+
+bool	is_use_redirect_out(int proc_out_fd)
+{
+	return (!(proc_out_fd == OUT_FD_INIT || proc_out_fd == REDIRECT_FAILURE));
+}
+
 static t_result	connect_redirect_in_to_proc(int *prev_fd, int in_fd)
 {
 	if (*prev_fd != IN_FD_INIT)
@@ -34,7 +44,7 @@ static t_result	connect_redirect_out_to_proc(int out_fd)
 
 t_result	connect_redirect_to_proc(int *prev_fd, int proc_fd[2])
 {
-	if (proc_fd[IN] != IN_FD_INIT)
+	if (is_use_redirect_in(proc_fd[IN]))
 	{
 		if (connect_redirect_in_to_proc(prev_fd, proc_fd[IN]) == PROCESS_ERROR)
 		{
@@ -42,7 +52,7 @@ t_result	connect_redirect_to_proc(int *prev_fd, int proc_fd[2])
 			return (PROCESS_ERROR);
 		}
 	}
-	if (proc_fd[OUT] != OUT_FD_INIT)
+	if (is_use_redirect_out(proc_fd[OUT]))
 	{
 		if (connect_redirect_out_to_proc(proc_fd[OUT]) == PROCESS_ERROR)
 		{

--- a/srcs/exec/redirect_connect_to_proc.c
+++ b/srcs/exec/redirect_connect_to_proc.c
@@ -6,12 +6,12 @@
 
 bool	is_use_redirect_in(int proc_in_fd)
 {
-	return (!(proc_in_fd == IN_FD_INIT || proc_in_fd == REDIRECT_FAILURE));
+	return (proc_in_fd != IN_FD_INIT);
 }
 
 bool	is_use_redirect_out(int proc_out_fd)
 {
-	return (!(proc_out_fd == OUT_FD_INIT || proc_out_fd == REDIRECT_FAILURE));
+	return (proc_out_fd != OUT_FD_INIT);
 }
 
 static t_result	connect_redirect_in_to_proc(int *prev_fd, int in_fd)

--- a/srcs/exec/redirect_open_fd.c
+++ b/srcs/exec/redirect_open_fd.c
@@ -7,6 +7,7 @@
 #include "ms_parse.h"
 #include "ft_deque.h"
 #include "ft_sys.h"
+#include "ft_string.h"
 
 static int	open_redirect_fd(const char *path, \
 								t_open_flag open_flag, \
@@ -15,6 +16,11 @@ static int	open_redirect_fd(const char *path, \
 	int	open_fd;
 
 	errno = 0;
+	*tmp_err = 0;
+	if (ft_streq(path, DEV_STDIN_PATH))
+		return (STDIN_FILENO);
+	if (ft_streq(path, DEV_STDOUT_PATH))
+		return (STDOUT_FILENO);
 	if (open_flag == OPEN_FOR_IN)
 		open_fd = open(path, open_flag);
 	else

--- a/srcs/exec/redirects.c
+++ b/srcs/exec/redirects.c
@@ -8,38 +8,31 @@
 #include "ft_string.h"
 #include "ft_sys.h"
 
-static void	assign_failure_fd_to_proc_fds(int proc_fd[2])
+void	assign_failure_fd_to_proc_fds(int proc_fd[2])
 {
 	proc_fd[IN] = REDIRECT_FAILURE;
 	proc_fd[OUT] = REDIRECT_FAILURE;
 }
 
-static t_result	exec_redirect_each(t_redirect *redirect, \
-									int proc_fd[2], \
-									t_context *context)
+static t_result	open_redirect_files_each(t_redirect *redirect, \
+											int proc_fd[2], \
+											t_context *context)
 {
 	t_result	result;
 	int			open_errno;
 	char		*path;
 
 	result = open_redirect_fd_and_save_to_proc(redirect, proc_fd, &open_errno);
-	if (result == FAILURE)
+	if (result == FAILURE || result == PROCESS_ERROR)
 	{
-		context->status = STATUS_REDIRECT_FAILURE;
 		path = get_head_token_str(redirect->tokens);
 		puterr_cmd_msg(path, strerror(open_errno));
+		context->status = STATUS_REDIRECT_FAILURE;
 	}
 	return (result);
 }
 
-// OK [redirect_symbol]-[file]
-// NG [redirect_symbol]-[redirect_symbol]: dropped $var
-//    [redirect_symbol]-[file]-[file]    : splitted $var
-
-// redirect_list != NULL
-// if redirect failure, proc_fd[IN/OUT] = (-1)
-static t_result	expand_and_exec_redirect_all(t_ast *self_node, \
-												t_context *context)
+static t_result	open_redirect_files(t_ast *self_node, t_context *context)
 {
 	t_deque_node	*node;
 	t_result		result;
@@ -49,17 +42,9 @@ static t_result	expand_and_exec_redirect_all(t_ast *self_node, \
 	while (node)
 	{
 		redirect = (t_redirect *)node->content;
-		result = expand_for_redirect(redirect, context);
+		result = open_redirect_files_each(redirect, self_node->proc_fd, context);
 		if (result == FAILURE || result == PROCESS_ERROR)
 		{
-			// init_fd to fail_fd
-			assign_failure_fd_to_proc_fds(self_node->proc_fd);
-			return (result);
-		}
-		result = exec_redirect_each(node->content, self_node->proc_fd, context);
-		if (result == FAILURE || result == PROCESS_ERROR)
-		{
-			// open_fd; closed to fail_fd
 			assign_failure_fd_to_proc_fds(self_node->proc_fd);
 			return (result);
 		}
@@ -90,7 +75,10 @@ t_result	redirect_fd(t_ast *self_node, t_context *context)
 
 	if (!self_node->redirect_list)
 		return (SUCCESS);
-	result = expand_and_exec_redirect_all(self_node, context);
+	result = expand_for_filename(self_node, context);
+	if (result == FAILURE || result == PROCESS_ERROR)
+		return (result);
+	result = open_redirect_files(self_node, context);
 	if (result == FAILURE || result == PROCESS_ERROR)
 		return (result);
 	if (ft_streq(command, CMD_EXIT))

--- a/srcs/exec/redirects.c
+++ b/srcs/exec/redirects.c
@@ -8,12 +8,6 @@
 #include "ft_string.h"
 #include "ft_sys.h"
 
-void	assign_failure_fd_to_proc_fds(int proc_fd[2])
-{
-	proc_fd[IN] = REDIRECT_FAILURE;
-	proc_fd[OUT] = REDIRECT_FAILURE;
-}
-
 static t_result	open_redirect_files_each(t_redirect *redirect, \
 											int proc_fd[2], \
 											t_context *context)
@@ -42,12 +36,11 @@ static t_result	open_redirect_files(t_ast *self_node, t_context *context)
 	while (node)
 	{
 		redirect = (t_redirect *)node->content;
-		result = open_redirect_files_each(redirect, self_node->proc_fd, context);
+		result = open_redirect_files_each(redirect, \
+											self_node->proc_fd, \
+											context);
 		if (result == FAILURE || result == PROCESS_ERROR)
-		{
-			assign_failure_fd_to_proc_fds(self_node->proc_fd);
 			return (result);
-		}
 		node = node->next;
 	}
 	return (SUCCESS);

--- a/srcs/exec/redirects.c
+++ b/srcs/exec/redirects.c
@@ -99,7 +99,7 @@ t_result	redirect_fd(t_ast *self_node, t_context *context)
 			return (PROCESS_ERROR);
 		return (SUCCESS);
 	}
-	result = connect_redirect_to_proc(self_node);
+	result = connect_redirect_to_proc(&self_node->prev_fd, self_node->proc_fd);
 	if (result == PROCESS_ERROR)
 		return (PROCESS_ERROR);
 	return (SUCCESS);

--- a/srcs/exec/single_builtin.c
+++ b/srcs/exec/single_builtin.c
@@ -34,10 +34,12 @@ bool	is_single_builtin_command(const t_ast *self_node)
 	return (true);
 }
 
-void	execute_single_builtin(t_ast *self_node, t_context *context)
+void	execute_single_builtin(t_ast *self_node, t_context *context, t_result redirect_result)
 {
 	char	**argv;
 
+	if (redirect_result == FAILURE)
+		return ;
 	argv = convert_command_to_argv(self_node->command);
 	context->status = call_builtin_command((const char *const *)argv, context);
 	free_2d_array(&argv);

--- a/srcs/exec/single_builtin.c
+++ b/srcs/exec/single_builtin.c
@@ -34,7 +34,9 @@ bool	is_single_builtin_command(const t_ast *self_node)
 	return (true);
 }
 
-void	execute_single_builtin(t_ast *self_node, t_context *context, t_result redirect_result)
+void	execute_single_builtin(t_ast *self_node, \
+								t_context *context, \
+								t_result redirect_result)
 {
 	char	**argv;
 

--- a/test/integration_test/run_all.py
+++ b/test/integration_test/run_all.py
@@ -1,5 +1,4 @@
-import glob
-
+from test_function.print_ng_case import print_ng_cases
 import run_builtin
 import run_pipe
 import run_op
@@ -17,16 +16,6 @@ def print_test_title(title):
     print(" *" + " " * len(title) * 4 + title + " " * len(title) * 4 + "* ")
     print(" " + "*" * (len(title) * 9 + 1) + " ")
     print(RESET)
-
-
-def print_ng_cases(test_res):
-    if not test_res:
-        return
-
-    for file in glob.glob('ko_case_*_cmd.txt'):
-        with open(file, 'r') as f:
-            print(f.read())
-    return
 
 
 def main():

--- a/test/integration_test/run_op.py
+++ b/test/integration_test/run_op.py
@@ -1,3 +1,4 @@
+from test_function.print_ng_case import print_ng_cases
 import run_and_or
 import run_mix
 import run_paren
@@ -13,6 +14,8 @@ def main():
     test_res |= run_redirects.main()
     test_res |= run_expansion.main()
     # test_res |= run_path.main()
+
+    print_ng_cases(test_res)
 
     return test_res
 

--- a/test/integration_test/run_redirects.py
+++ b/test/integration_test/run_redirects.py
@@ -99,15 +99,15 @@ def main():
         "cat <<eof1<<eof2\neof11\neof\neof1\neof22\n$HOME$hoge$PWD\neof2\n",
         "rm -f out1 out2\ncat << eof>out1>out2 \ntest1\ntest2\n$HOME\n\"$HOME\"\n'$HOME'\neof\ncat out1\ncatou2\nrm -f out1 out2",
         "cat -e << 'eof' \ntest1\ntest2\n$HOME\n\"$HOME\"\n'$HOME'\neof",
-        "cat -e << '' \ntest1\ntest2\n$HOME\n\"$HOME\"\n'$HOME'\n\n",
+        "cat -e << '' \ntest1\ntest2\n$HOME\n\"$HOME\"\n'$HOME'\n\'\'\n\"\"\n\n",
         "cat -e << \"\" \ntest1\ntest2\n$HOME\n\"$HOME\"\n'$HOME'\n\n",
-        "cat << $HOME \ntest1\ntest2\n$HOME\n\"$HOME\"\n'$HOME'\n$HOME",
-        "cat << '$HOME' \ntest1\ntest2\n$HOME\n\"$HOME\"\n'$HOME'\n$HOME",
-        "cat << \"$HOME\" \ntest1\ntest2\n$HOME\n\"$HOME\"\n'$HOME'\n$HOME$USER$hoge $huga$PWD",
-        "cat << $nothing \ntest1\n\ntest2\n$HOME\n\"$HOME\"\n'$HOME'\n$nothing",
+        "cat << $HOME \ntest1\ntest2\n$HOMEee\n\"$HOME\"\n'$HOME'\n$HOME",
+        "cat << '$HOME' \ntest1\ntest2\n$HOMEee\n\"$HOME\"\n'$HOME'\n$HOME",
+        "cat << \"$HOME\" \ntest1\ntest2\n$HOMEee\n\"$HOME\"\n'$HOME'\n$HOME$USER$hoge $huga$PWD\n$HOME",
+        "cat << $nothing \ntest1\n\ntest2\n$HOMEee\n\"$HOME\"\n'$HOME'\n$nothing",
         "cat -e << 'e'o\"f\" \ntest1\n\ntest2\n$?$HOME$?\n\"$HOME\"\n'$HOME'\neof",
         "cat << a\n$HOME\"\"\n\n        '$hoge'$hoge\n '\n\"\na",
-        f"cat << eof\n{BIG}\neof\n | wc",
+        f"cat << eof | wc \n{BIG}\neof\n",
         ]  # todo more test
 
     test_res |= test("redirect_in_error", redirects_in_error_test, False)

--- a/test/integration_test/run_redirects.py
+++ b/test/integration_test/run_redirects.py
@@ -1,4 +1,5 @@
 from test_function.test_functions import test
+from test_function.print_ng_case import print_ng_cases
 
 def main():
     test_res = 0
@@ -116,6 +117,8 @@ def main():
     test_res |= test("redirect_out", redirects_out_test, False)
     test_res |= test("redirect_append", redirects_append_test, False)
     test_res |= test("redirect_heredoc", redirects_heredoc_test, False)
+
+    print_ng_cases(test_res)
 
     return test_res
 

--- a/test/integration_test/run_redirects.py
+++ b/test/integration_test/run_redirects.py
@@ -41,45 +41,45 @@ def main():
                     "echo hello </dev/stdin | cat >/dev/stdout | cat -e"
                     ] # todo more test
 
+    RMFILES = "rm -f test_infile1 && rm -f test_infile1 && rm -f test_infile2"
     redirects_in_test =[
-                    "echo aa >test_infile1 && echo bb > test_infile2",
-                    "cat test_infile1 && cat test_infille2 && cat <test_infile1",
-                    "cat test_infile1 && cat test_infille2 && cat < test_infile1",
-                    "cat test_infile1 && cat test_infille2 && cat <     test_infile1",
-                    "cat test_infile1 && cat test_infille2 && cat <test_infile1 && cat<test_infile1",
-                    "cat test_infile1 && cat test_infille2 && cat <test_infile1 && cat<test_infile2",
-                    "cat test_infile1 && cat test_infille2 && cat <test_infile1 || cat<test_infile1",
-                    "cat test_infile1 && cat test_infille2 && cat <test_infile1 || cat<test_infile2",
-                    "cat test_infile1 && cat test_infille2 && cat <test_infile1 | cat<test_infile2",
-                    "cat test_infile1 && cat test_infille2 && cat<test_infile1 | cat <test_infile2",
-                    "cat test_infile1 && cat test_infille2 && cat <test_infile1 | cat <test_infile2 | cat",
-                    "cat test_infile1 && cat test_infille2 && cat <test_infile1 | cat <test_infile2 | cat | cat",
-                    "cat test_infile1 && cat test_infille2 && cat <test_infile1 <test_infile2 | cat",
-                    "cat test_infile1 && cat test_infille2 && cat <test_infile1 <test_infile1 | cat",
-                    "cat test_infile1 && cat test_infille2 && cat <test_infile2 | cat <test_infile2 <test_infile1 | cat | cat",
-                    "cat test_infile1 && cat test_infille2 && cat <    test_infile1<test_infile2 | cat",
-                    "cat test_infile1 && cat test_infille2 && <test_infile1 | cat",
-                    "cat test_infile1 && cat test_infille2 && <test_infile1 | cat | grep nothing",
+                    f"{RMFILES} \n echo aa >test_infile1 && echo bb > test_infile2\n{RMFILES}",
+                    f"cat test_infile1 && cat test_infille2 && cat <test_infile1\n{RMFILES}",
+                    f"cat test_infile1 && cat test_infille2 && cat < test_infile1\n{RMFILES}",
+                    f"cat test_infile1 && cat test_infille2 && cat <     test_infile1\n{RMFILES}",
+                    f"cat test_infile1 && cat test_infille2 && cat <test_infile1 && cat<test_infile1\n{RMFILES}",
+                    f"cat test_infile1 && cat test_infille2 && cat <test_infile1 && cat<test_infile2\n{RMFILES}",
+                    f"cat test_infile1 && cat test_infille2 && cat <test_infile1 || cat<test_infile1\n{RMFILES}",
+                    f"cat test_infile1 && cat test_infille2 && cat <test_infile1 || cat<test_infile2\n{RMFILES}",
+                    f"cat test_infile1 && cat test_infille2 && cat <test_infile1 | cat<test_infile2\n{RMFILES}",
+                    f"cat test_infile1 && cat test_infille2 && cat<test_infile1 | cat <test_infile2\n{RMFILES}",
+                    f"cat test_infile1 && cat test_infille2 && cat <test_infile1 | cat <test_infile2 | cat\n{RMFILES}",
+                    f"cat test_infile1 && cat test_infille2 && cat <test_infile1 | cat <test_infile2 | cat | cat\n{RMFILES}",
+                    f"cat test_infile1 && cat test_infille2 && cat <test_infile1 <test_infile2 | cat\n{RMFILES}",
+                    f"cat test_infile1 && cat test_infille2 && cat <test_infile1 <test_infile1 | cat\n{RMFILES}",
+                    f"cat test_infile1 && cat test_infille2 && cat <test_infile2 | cat <test_infile2 <test_infile1 | cat | cat\n{RMFILES}",
+                    f"cat test_infile1 && cat test_infille2 && cat <    test_infile1<test_infile2 | cat\n{RMFILES}",
+                    f"cat test_infile1 && cat test_infille2 && <test_infile1 | cat\n{RMFILES}",
+                    f"cat test_infile1 && cat test_infille2 && <test_infile1 | cat | grep nothing\n{RMFILES}",
                     # "cat test_infile1 && cat test_infille2 && <test_infile1 | cat | grep a", # for actions
-                    "cat test_infile1 && cat test_infille2 && <test_infile1 <test_infile2 | cat",
-                    "rm -f test_infile1 && rm -f test_infile1 && rm -f test_infile2"
+                    f"cat test_infile1 && cat test_infille2 && <test_infile1 <test_infile2 | cat \n{RMFILES}",
+                    # "rm -f test_infile1 && rm -f test_infile1 && rm -f test_infile2"
                     ]
 
     redirects_out_test = [
-                    "echo aa >test_outfile1 && cat test_outfile1",
-                    "echo bb > test_outfile1 && cat test_outfile1",
-                    "echo cc >            test_outfile1 && cat test_outfile1",
-                    "echo dd >test_outfile1 && cat test_outfile1 && cat test_outfile1",
-                    "echo ee >test_outfile1 || cat test_outfile1 && cat test_outfile1",
+                    f"{RMFILES} \n echo aa >test_outfile1 && cat test_outfile1\n{RMFILES}",
+                    f"echo bb > test_outfile1 && cat test_outfile1\n{RMFILES}",
+                    f"echo cc >            test_outfile1 && cat test_outfile1\n{RMFILES}",
+                    f"echo dd >test_outfile1 && cat test_outfile1 && cat test_outfile1\n{RMFILES}",
+                    f"echo ee >test_outfile1 || cat test_outfile1 && cat test_outfile1\n{RMFILES}",
                     # "echo ff >test_outfile1 | cat test_outfile1 && cat test_outfile1", # for actions
-                    "echo gg >test_outfile1 | echo hh >test_outfile2 && cat test_outfile1 && cat test_outfile2",
-                    "echo ii >test_outfile1 | echo jj >test_outfile2 | cat && cat test_outfile1 && cat test_outfile2",
-                    "echo kk >test_outfile1 | echo ll >test_outfile2 | cat | cat && cat test_outfile1 && cat test_outfile2",
-                    "echo mm >test_outfile1 < test_outfile2 | cat && cat test_outfile1 && cat test_outfile2",
-                    "echo nn >    test_outfile1 <test_outfile2 | cat && cat test_outfile1 && cat test_outfile2",
-                    ">test_outfile1 echo oo | cat && cat test_outfile1",
-                    ">test_outfile1 >test_outfile2     echo pp | cat && cat test_outfile1 && cat test_outfile2",
-                    "rm -f test_outfile1 && rm -f test_outfile1 && rm -f test_outfile2"
+                    f"echo gg >test_outfile1 | echo hh >test_outfile2 && cat test_outfile1 && cat test_outfile2\n{RMFILES}",
+                    f"echo ii >test_outfile1 | echo jj >test_outfile2 | cat && cat test_outfile1 && cat test_outfile2\n{RMFILES}",
+                    f"echo kk >test_outfile1 | echo ll >test_outfile2 | cat | cat && cat test_outfile1 && cat test_outfile2\n{RMFILES}",
+                    f"echo mm >test_outfile1 < test_outfile2 | cat && cat test_outfile1 && cat test_outfile2\n{RMFILES}",
+                    f"echo nn >    test_outfile1 <test_outfile2 | cat && cat test_outfile1 && cat test_outfile2\n{RMFILES}",
+                    f">test_outfile1 echo oo | cat && cat test_outfile1\n{RMFILES}",
+                    f">test_outfile1 >test_outfile2     echo pp | cat && cat test_outfile1 && cat test_outfile2\n{RMFILES}",
                     ]
 
     redirects_append_test = [
@@ -108,8 +108,8 @@ def main():
         "cat -e << 'e'o\"f\" \ntest1\n\ntest2\n$?$HOME$?\n\"$HOME\"\n'$HOME'\neof",
         "cat << a\n$HOME\"\"\n\n        '$hoge'$hoge\n '\n\"\na",
         f"cat << eof | wc \n{BIG}\neof\n",
+        "<no |<no <<eof <no cat -e && <<eof2 cat -e\ntest1\n$HOME\neof\ntest2\n$HOME\neof2\n",
         ]  # todo more test
-
     test_res |= test("redirect_in_error", redirects_in_error_test, False)
     test_res |= test("redirect_out_error", redirects_out_error_test, False)
     test_res |= test("redirect_in", redirects_in_test, False)

--- a/test/integration_test/run_redirects.py
+++ b/test/integration_test/run_redirects.py
@@ -19,6 +19,7 @@ def main():
                     "nosuchfile < && nosuchfile1 <",
                     "nosuchfile < && < nosuchfile1",
                     "< nosuchfile && < nosuchfile1 < nosuchfile2",
+                    "cat -e < /dev/stdin\naaa\nbbb\nccc"
                     ] # todo more test
 
     redirects_out_error_test = [
@@ -35,6 +36,9 @@ def main():
                     # "nosuchfile > && nosuchfile1 >",
                     # "nosuchfile > && > nosuchfile1",
                     # "> nosuchfile && > nosuchfile1 > nosuchfile2",
+                    "echo hello >/dev/stdout",
+                    "echo hello >/dev/stdout | cat -e",
+                    "echo hello </dev/stdin | cat >/dev/stdout | cat -e"
                     ] # todo more test
 
     redirects_in_test =[

--- a/test/integration_test/test_function/print_ng_case.py
+++ b/test/integration_test/test_function/print_ng_case.py
@@ -1,0 +1,11 @@
+import glob
+
+
+def print_ng_cases(test_res):
+    if not test_res:
+        return
+
+    for file in glob.glob('ko_case_*_cmd.txt'):
+        with open(file, 'r') as f:
+            print(f.read())
+    return

--- a/test/integration_test/test_function/test_functions.py
+++ b/test/integration_test/test_function/test_functions.py
@@ -56,13 +56,17 @@ def save_ko_cmd(test_name, out_ko_case, val_ko_case):
     with open(f'ko_case_{test_name}_cmd.txt', 'w') as f:
         if len(out_ko_case):
             f.write(f'[OUTPUT KO CASE OF : {test_name}]\n')
+            f.write(f'{"-" * 100}\n')
             for stdin, _, _ in out_ko_case:
                 f.write(f'{stdin}\n')
+                f.write(f'{"-" * 100}\n')
 
         if len(val_ko_case):
             f.write(f'[LEAK or FD KO CASE OF : {test_name}]\n')
+            f.write(f'{"-" * 100}\n')
             for ko in val_ko_case:
                 f.write(f'{ko}\n')
+                f.write(f'{"-" * 100}\n')
             # for stdin, _, _ in val_ko_case:
             #     f.write(f'{stdin}\n')
 
@@ -94,6 +98,7 @@ def save_ko_out(test_name, out_ko_case, val_ko_case):
     with open(f'ko_case_{test_name}_out.txt', 'w') as f:
         if len(out_ko_case):
             f.write(f'[OUTPUT KO CASE OF : {test_name}]\n')
+            f.write(f'{"-" * 100}\n')
             for ko in out_ko_case:
                 stdin, m_res, b_res = ko
                 write_out_to_file("minishell", stdin, m_res, f)
@@ -102,9 +107,10 @@ def save_ko_out(test_name, out_ko_case, val_ko_case):
 
         if len(val_ko_case):
             f.write(f'[LEAK or FD KO CASE OF : {test_name}]\n')
-
+            f.write(f'{"-" * 100}\n')
             for ko in val_ko_case:
                 f.write(ko)
+                f.write(f'{"-" * 100}\n')
                 # stdin, m_res, b_res = ko
                 # write_val_to_f("minishell", stdin, m_res, f)
                 # write_val_to_f("bash", stdin, b_res, f)
@@ -132,13 +138,17 @@ def print_ko_case(test_name, test_res, out_ko_case, val_ko_case):
 
     if len(out_ko_case):
         print(f'[OUTPUT KO CASE OF : {test_name}]')
+        print('-' * 100)
         for stdin, _, _ in out_ko_case:
             print(stdin)
+            print('-' * 100)
 
     if len(val_ko_case):
         print(f'[LEAK or FD KO CASE OF : {test_name}]')
+        print('-' * 100)
         for ko in val_ko_case:
             print(ko)
+            print('-' * 100)
     #     for stdin, _, _ in val_ko_case:
     #         print(stdin)
 

--- a/test/integration_test/test_function/test_output.py
+++ b/test/integration_test/test_function/test_output.py
@@ -201,14 +201,16 @@ def put_output_and_result(test_no, stdin, val, m_res, b_res, status_only, ko_cas
 
 def put_total_result(val):
     test_num, ok, ko = val
-    print("#########################################")
-    print(" TOTAL RESULT : ", end="")
-    print_color_str_no_lf(GREEN, "OK ")
-    print(f'{ok}, ', end="")
-    print_color_str_no_lf(RED, "KO ")
-    print(ko, end="")
-    print(f' (test case: {test_num - 1})')
-    print("#########################################\n")
+    if ok == test_num - 1:
+        color = GREEN
+    else:
+        color = RED
+    print_color_str(color,
+                    f"#########################################\n"
+                    f"TOTAL RESULT (test case: {test_num - 1})\n"
+                    f"  OK {ok}\n"
+                    f"  KO {ko}\n"
+                    f"#########################################\n\n")
     if ok == test_num - 1:
         return 0
     else:

--- a/test/integration_test/test_function/test_valgrind.py
+++ b/test/integration_test/test_function/test_valgrind.py
@@ -171,19 +171,24 @@ def put_valgrind_result(val_res, m_res):
 
 def put_total_valgrind_result(val_res):
     test_num, ok, leak_ng, fd_ng, skip = val_res
-    print("#########################################")
-    print(" LEAK TOTAL RESULT : ", end="")
-    print_color_str_no_lf(GREEN, "OK ")
-    print(f'{ok}, ', end="")
-    print_color_str_no_lf(RED, "LEAK_NG ")
-    print(f'{leak_ng}, ', end="")
-    print_color_str_no_lf(RED, "FD_NG ")
-    print(f'{fd_ng}, ', end="")
-    print_color_str_no_lf(YELLOW, "SKIP ")
-    print(skip, end="")
-    print(f' (test case: {test_num - 1})')
-    print("#########################################\n")
-    if ok == test_num - 1:
+
+    if skip:
+        color = YELLOW
+    elif ok == test_num - 1:
+        color = GREEN
+    else:
+        color = RED
+
+    print_color_str(color,
+                    f"#########################################\n"
+                    f"LEAK/FD TOTAL RESULT (test case: {test_num - 1})\n"
+                    f"  OK {ok}\n"
+                    f"  LEAK_KO {leak_ng}\n"
+                    f"  FD_KO {fd_ng}\n"
+                    f"  SKIP {skip}\n"
+                    f"#########################################\n\n")
+
+    if ok == test_num - 1 - skip:
         return 0
     else:
         return 1


### PR DESCRIPTION
* #290 を丁寧に再実装 [memo diff](https://github.com/habvi/42_minishell/compare/f2b8d996e108556b290addaecf852ad8a5cb77ff...65eb881e10f685c06ce6e40009bb47c4fbdaf629?expand=1)
* バグの原因がよくわからなかったので、段階的にテスト＆commitしていくことに...（test_redirects通ったケースのみcommit）
* 変更点
  - [x] redirect fileに`/dev/stdin`, `/dev/stdout`が指定された際の挙動を修正。open(path)せずにSTDIN_FILENO, STDOUT_FILENOを渡す 242273f
  - [x] `< redirect_error | cat`などケースで, redirect_errorの次のpipeへの入力が不正だった点を修正
    - redirect失敗時にproc_fd[IN/OUT]をREDIRECT_FAILURE(-1)で埋める bdf3807
    - ~`execute_command_internal()`周りの関数整理 c6ee0f6~
    - ~redirect failureの情報をexec関係の関数に渡し、exit(1)などの処理（コマンド実行はしない） 436c23c~
      * 子プロセス内でexpand, redirectができれば、redirect failureの情報を伝達する必要はないが、single builtinの扱いに困る... 
      * 子プロセス内でredirect実行した方が自然かも...?? -> できそうだったので見直した
      * redirectの実行をexecute_command直前で実行するよう変更し、redirect失敗で即reutrn(FAILURE)可能になった。 44f69bc
      * child_procを生成する場合は、child_proc内でリダイレクトし、失敗時にexitする。pipe内のfdを変更するだけなので、stdin/outのbackupは不要。
      * single_builtinはコマンド実行前にredirectし、失敗時にreturn(FAILURE)する。parent_procでの実行のため、stdin/outのbackupが必要
      * heredocの展開はfilenameが変更される。unlinkの関係上、予めexpandしてからexec funcを呼ぶ。
  - [x] refactor（バグらない範囲で...） 55628da 319e642 7cefd4f 6e44ce4 d9c6d94
- [x] ついでに...test関係のupdate
  - test_redirect, mixなど, `run_all`以外に複数のテストを含むテストにおいて、一通り実行した後にKO caseをprintするよう変更 43f2423
    * `make test_redirects` などを実行した際に、序盤のテストの結果はko_case fileを見に行かなければわからず、NGを見落とすため
    * `make test_all`実行の際には各テスト終了段階ででko caseがprintされ、テスト終了時にも重複してprintされる仕様だが許容...
  - total resultのfmt, colorを変更し、一見でOK/NGを把握可能に 9b53d6c
    * before : <img src="https://github.com/habvi/42_minishell/assets/51146172/b3393089-7693-4621-b1c0-73072ed051f7" width="200">
    * after(OK) :  <img src="https://github.com/habvi/42_minishell/assets/51146172/3c32cbfe-5500-46fe-a107-43db67d79a45" width="200">
    * after(KO) : <img src="https://github.com/habvi/42_minishell/assets/51146172/807182e5-b4d7-4431-8d86-293890a6b7ec" width="200">


<br>

---

バグ（input file is output file, redirect in/outとstdin/outがつながりっぱなし）の原因だったらしきもの
- [backup stdin/outの最適化](https://github.com/habvi/42_minishell/compare/f2b8d996e108556b290addaecf852ad8a5cb77ff...65eb881e10f685c06ce6e40009bb47c4fbdaf629?expand=1#diff-beb78e09913ecb9ea0af5c016d58448893a4c0168421a4818dad23d483cd28faR24-R37)
  - proc_fdがINITでない場合のみ、redirectを使用しているのでstdin or outのbackupを撮れば良さそう...と思い実装した関数
  - この処理があると`echo a >out && cat out`などで、input file is output fileになる。問題なさそうなのになぜか...
- [redirect 失敗時のparent->prev_fd操作](https://github.com/habvi/42_minishell/compare/f2b8d996e108556b290addaecf852ad8a5cb77ff...65eb881e10f685c06ce6e40009bb47c4fbdaf629?expand=1#diff-9dc5f5d228359036397dc86c577d4963c439e55e0a5fb9a5763eef569af8a174R8)
  - redirect失敗時にもpipeを作りにいくよう変更したので、parent_procのclose(prev_fd)で十分だったらしい。
  - これがあると`cat <in | cat -e`などでpipeに出力されなくなった気がする。