### PR TITLE
minor refactor ab

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -187,6 +187,7 @@ SRCS		+=	$(UTILS_DIR)/count_array.c \
 				$(UTILS_DIR)/is_valid_key.c \
 				$(UTILS_DIR)/is_valid_path.c \
 				$(UTILS_DIR)/x_ft_itoa.c \
+				$(UTILS_DIR)/x_ft_split.c \
 				$(UTILS_DIR)/x_ft_strdup.c \
 				$(UTILS_DIR)/x_ft_strjoin.c \
 				$(UTILS_DIR)/x_ft_substr.c

--- a/Makefile
+++ b/Makefile
@@ -250,6 +250,17 @@ sani	:
 norm	:
 	python3 ./test/integration_test/norm.py
 
+.PHONY	: readline
+readline:
+ifeq ($(UNAME), Linux)
+	sudo apt-get install libreadline8
+	sudo apt-get install libreadline-dev
+else
+ifeq ($(UNAME), Darwin)
+	curl -fsSL https://rawgit.com/kube/42homebrew/master/install.sh | zsh
+	brew update && brew upgrade && brew install readline
+endif
+endif
 
 #--------------------------------------------
 # test.bats

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -118,7 +118,8 @@ size_t		count_argv(const char *const *argc);
 char		*extend_str(char *left, char *right);
 void		ft_abort(void);
 char		*get_current_path(int *tmp_err);
-char		*get_working_directory(const char *for_whom);
+char		*get_working_directory(const char *for_whom, t_result *result);
+bool		is_getcwd_failure(const int tmp_err);
 bool		is_valid_key(const char *word);
 bool		is_valid_head(const char c);
 bool		is_valid_after_head(const char c);
@@ -139,7 +140,7 @@ char		*get_random_str(const size_t size);
 char		*ft_get_next_line(int fd, t_result *result);
 
 /* init */
-void		init_context(t_context *context, \
+t_result	init_context(t_context *context, \
 							bool is_forced_interactive, \
 							bool is_test);
 t_result	analyze_option(int argc, \

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -128,6 +128,7 @@ bool		is_a_directory_by_stat(const char *path, t_result *result);
 bool		is_file_by_stat(const char *path, t_result *result);
 bool		test_opendir_strict(const char *path, t_result *result);
 char		*x_ft_itoa(int n);
+char		**x_ft_split(char const *str, char c);
 char		*x_ft_strdup(const char *str);
 char		*x_ft_strndup(const char *str, const size_t maxlen);
 char		*x_ft_strjoin(char const *s1, char const *s2);

--- a/includes/ms_builtin.h
+++ b/includes/ms_builtin.h
@@ -142,8 +142,8 @@ void		add_split_path_elems(t_deque *path_elems, const char *path);
 void		erase_dot_path_for_relative(t_deque **path_elems);
 void		erase_dot_path(t_deque **path_elems);
 void		erase_dot_dot_path(t_deque **path_elems);
-char		*convert_path_elems_to_absolute_path(t_deque *path_elems, \
-													const char *internal_pwd);
+char		*convert_path_elems_to_path(t_deque *path_elems, \
+										const char *internal_pwd);
 char		*search_cdpath(const char *arg, t_var *var, bool *is_print_path);
 
 bool		is_absolute_path(const char *path);

--- a/includes/ms_tokenize.h
+++ b/includes/ms_tokenize.h
@@ -57,7 +57,7 @@ typedef struct s_token {
 }	t_token;
 
 /* tokenize */
-t_deque			*tokenize(char *line, t_context *context, t_result *result);
+t_deque			*tokenize(char **line, t_context *context, t_result *result);
 t_deque			*tokenize_line(char *line);
 t_token_kind	get_token_kind(t_deque_node *token_node);
 char			*get_token_str(char *head, char **end);

--- a/includes/ms_var.h
+++ b/includes/ms_var.h
@@ -62,8 +62,8 @@ struct s_var
 
 /* init */
 t_var		*set_default_environ(void);
-void		set_default_pwd(t_var *var);
-void		set_default_old_pwd(t_var *var);
+t_result	set_default_pwd(t_var *var);
+t_result	set_default_old_pwd(t_var *var);
 
 /* create, dup */
 void		var_declare_all(const char *const *args, \

--- a/libft/includes/ft_mem.h
+++ b/libft/includes/ft_mem.h
@@ -4,7 +4,7 @@
 # include <stddef.h>
 
 /* free */
-void	*ft_free(void *ptr);
+void	*ft_free(void **ptr);
 void	*free_2d_array(char ***ptr);
 
 void	ft_bzero(void *s, size_t n);

--- a/libft/srcs/ft_deque/dq_clear_all.c
+++ b/libft/srcs/ft_deque/dq_clear_all.c
@@ -8,7 +8,7 @@ void	deque_clear_all(t_deque **deque, void (*del)(void *))
 
 	if (deque_is_empty(*deque))
 	{
-		ft_free(deque);
+		ft_free((void **)deque);
 		return ;
 	}
 	node = (*deque)->node;
@@ -18,5 +18,5 @@ void	deque_clear_all(t_deque **deque, void (*del)(void *))
 		node = node->next;
 		deque_clear_node(&tmp, del);
 	}
-	ft_free(deque);
+	ft_free((void **)deque);
 }

--- a/libft/srcs/ft_deque/dq_clear_node.c
+++ b/libft/srcs/ft_deque/dq_clear_node.c
@@ -9,5 +9,5 @@ void	deque_clear_node(t_deque_node **node, void (*del)(void *))
 	(*node)->content = NULL;
 	(*node)->next = NULL;
 	(*node)->prev = NULL;
-	ft_free(node);
+	ft_free((void **)node);
 }

--- a/libft/srcs/ft_dprintf/handle_info.c
+++ b/libft/srcs/ft_dprintf/handle_info.c
@@ -47,7 +47,7 @@ void	clear_fmt_info(t_info_pf *info)
 
 void	free_dup_str(t_info_pf *info)
 {
-	ft_free(&info->dup_str);
+	ft_free((void **)&info->dup_str);
 }
 
 void	put_output(int fd, t_info_pf *info)
@@ -57,10 +57,10 @@ void	put_output(int fd, t_info_pf *info)
 	res = write(fd, info->output, info->index);
 	if (res == ERROR_WRITE || info->total_len + res >= INT_MAX)
 	{
-		ft_free(&info->output);
+		ft_free((void **)&info->output);
 		info->error = EXIT;
 		return ;
 	}
 	info->total_len += res;
-	ft_free(&info->output);
+	ft_free((void **)&info->output);
 }

--- a/libft/srcs/ft_hash/hs_clear.c
+++ b/libft/srcs/ft_hash/hs_clear.c
@@ -6,9 +6,9 @@ void	hs_clear_elem(t_elem **elem, void (*del_hash_value)(void **))
 {
 	if (!elem || !*elem)
 		return ;
-	ft_free(&(*elem)->key);
+	ft_free((void **)&(*elem)->key);
 	del_hash_value(&(*elem)->value);
-	ft_free(elem);
+	ft_free((void **)elem);
 }
 
 void	hs_clear_deque_node(t_deque_node **node, \
@@ -22,7 +22,7 @@ void	hs_clear_deque_node(t_deque_node **node, \
 	hs_clear_elem(&elem, del_hash_value);
 	(*node)->next = NULL;
 	(*node)->prev = NULL;
-	ft_free(node);
+	ft_free((void **)node);
 }
 
 static void	hash_clear_deque_all(t_deque **deque, \
@@ -33,7 +33,7 @@ static void	hash_clear_deque_all(t_deque **deque, \
 
 	if (deque_is_empty(*deque))
 	{
-		ft_free(deque);
+		ft_free((void **)deque);
 		*deque = NULL;
 		return ;
 	}
@@ -44,7 +44,7 @@ static void	hash_clear_deque_all(t_deque **deque, \
 		node = node->next;
 		hs_clear_deque_node(&tmp, del_hash_value);
 	}
-	ft_free(deque);
+	ft_free((void **)deque);
 	*deque = NULL;
 }
 
@@ -63,7 +63,7 @@ void	hs_clear_table(t_deque **table, \
 			hash_clear_deque_all(&table[idx], del_hash_value);
 		idx++;
 	}
-	ft_free(&table);
+	ft_free((void **)&table);
 }
 
 void	hs_clear(t_hash **hash)
@@ -73,5 +73,5 @@ void	hs_clear(t_hash **hash)
 	hs_clear_table((*hash)->table, \
 					(*hash)->table_size, \
 					(*hash)->del_hash_value);
-	ft_free(hash);
+	ft_free((void **)hash);
 }

--- a/libft/srcs/ft_hash/hs_create_table.c
+++ b/libft/srcs/ft_hash/hs_create_table.c
@@ -18,7 +18,7 @@ t_hash	*hs_create_table(size_t size, void (*del_hash_value)(void **))
 	hash->table = (t_deque **)ft_calloc(hash->table_size, sizeof(t_deque *));
 	if (!hash->table)
 	{
-		ft_free(&hash);
+		ft_free((void **)&hash);
 		return (NULL);
 	}
 	hash->del_hash_value = del_hash_value;

--- a/libft/srcs/ft_hash/hs_update_value.c
+++ b/libft/srcs/ft_hash/hs_update_value.c
@@ -11,7 +11,7 @@ void	hs_update_value(char **key, \
 {
 	t_elem	*elem;
 
-	ft_free(key);
+	ft_free((void **)key);
 	elem = (t_elem *)target_node->content;
 	del_hash_value(&elem->value);
 	elem->value = value;

--- a/libft/srcs/ft_list/ft_lstdelone.c
+++ b/libft/srcs/ft_list/ft_lstdelone.c
@@ -7,5 +7,5 @@ void	ft_lstdelone(t_list *lst, void (*del)(void*))
 		return ;
 	if (del)
 		del(lst->content);
-	ft_free(&lst);
+	ft_free((void **)&lst);
 }

--- a/srcs/builtin/ft_cd/canonicalize.c
+++ b/srcs/builtin/ft_cd/canonicalize.c
@@ -22,7 +22,7 @@ static void	handle_double_slash_path(const char *path, char **new_path)
 	if (is_head_double_slash(path))
 	{
 		tmp = x_ft_strjoin(PATH_DELIMITER_STR, *new_path);
-		ft_free(new_path);
+		ft_free((void **)new_path);
 		*new_path = tmp;
 	}
 }

--- a/srcs/builtin/ft_cd/canonicalize.c
+++ b/srcs/builtin/ft_cd/canonicalize.c
@@ -15,15 +15,15 @@ static void	erase_unnecessary_path_elem(t_deque **path_elems, \
 	}
 }
 
-static void	handle_double_slash_path(const char *path, char **absolute_path)
+static void	handle_double_slash_path(const char *path, char **new_path)
 {
-	char	*new_path;
+	char	*tmp;
 
 	if (is_head_double_slash(path))
 	{
-		new_path = x_ft_strjoin(PATH_DELIMITER_STR, *absolute_path);
-		ft_free(absolute_path);
-		*absolute_path = new_path;
+		tmp = x_ft_strjoin(PATH_DELIMITER_STR, *new_path);
+		ft_free(new_path);
+		*new_path = tmp;
 	}
 }
 
@@ -51,7 +51,7 @@ char	*cd_canonicalize_path(const char *internal_pwd, const char *path)
 	path_elems = allocate_path_elems();
 	path_elems = separate_path_and_join(path, internal_pwd, path_elems);
 	erase_unnecessary_path_elem(&path_elems, internal_pwd);
-	new_path = convert_path_elems_to_absolute_path(path_elems, internal_pwd);
+	new_path = convert_path_elems_to_path(path_elems, internal_pwd);
 	handle_double_slash_path(path, &new_path);
 	destroy_path_elems(&path_elems);
 	return (new_path);

--- a/srcs/builtin/ft_cd/canonicalize_convert.c
+++ b/srcs/builtin/ft_cd/canonicalize_convert.c
@@ -27,26 +27,22 @@ static size_t	calc_len_path(t_deque *path_elems, const char *internal_pwd)
 	return (len_path);
 }
 
-// todo: func name. not only absolute
-static char	*allocate_absolute_path(t_deque *path_elems, \
-									const char *internal_pwd)
+static char	*allocate_new_path(t_deque *path_elems, const char *internal_pwd)
 {
 	const size_t	len_path = calc_len_path(path_elems, internal_pwd);
-	char			*absolute_path;
+	char			*new_path;
 
-	absolute_path = (char *)x_malloc(sizeof(char) * (len_path + 1));
-	if (!absolute_path)
+	new_path = (char *)x_malloc(sizeof(char) * (len_path + 1));
+	if (!new_path)
 		ft_abort();
-	return (absolute_path);
+	return (new_path);
 }
 
-static void	strlcpy_path_elem(char *absolute_path, \
-								size_t *i, \
-								const char *path_elem)
+static void	strlcpy_path_elem(char *new_path, size_t *i, const char *path_elem)
 {
 	const size_t	len_path_elem = ft_strlen(path_elem);
 
-	ft_strlcpy_void(&absolute_path[*i], path_elem, len_path_elem + 1);
+	ft_strlcpy_void(&new_path[*i], path_elem, len_path_elem + 1);
 	(*i) += len_path_elem;
 }
 
@@ -55,26 +51,26 @@ static bool	is_last_path_elems(t_deque_node *node)
 	return (!node->next);
 }
 
-char	*convert_path_elems_to_absolute_path(t_deque *path_elems, \
-												const char *internal_pwd)
+char	*convert_path_elems_to_path(t_deque *path_elems, \
+									const char *internal_pwd)
 {
-	char			*absolute_path;
+	char			*new_path;
 	size_t			i;
 	t_deque_node	*node;
 	char			*path_elem;
 
-	absolute_path = allocate_absolute_path(path_elems, internal_pwd);
+	new_path = allocate_new_path(path_elems, internal_pwd);
 	i = 0;
 	if (is_absolute_path(internal_pwd))
-		strlcpy_path_elem(absolute_path, &i, PATH_DELIMITER_STR);
+		strlcpy_path_elem(new_path, &i, PATH_DELIMITER_STR);
 	node = path_elems->node;
 	while (node)
 	{
 		path_elem = (char *)node->content;
-		strlcpy_path_elem(absolute_path, &i, path_elem);
+		strlcpy_path_elem(new_path, &i, path_elem);
 		if (!is_last_path_elems(node))
-			strlcpy_path_elem(absolute_path, &i, PATH_DELIMITER_STR);
+			strlcpy_path_elem(new_path, &i, PATH_DELIMITER_STR);
 		node = node->next;
 	}
-	return (absolute_path);
+	return (new_path);
 }

--- a/srcs/builtin/ft_cd/canonicalize_sep_join.c
+++ b/srcs/builtin/ft_cd/canonicalize_sep_join.c
@@ -26,7 +26,7 @@ void	add_split_path_elems(t_deque *path_elems, const char *path)
 
 	split_path = x_ft_split(path, PATH_DELIMITER_CHR);
 	add_split_path_to_path_elems(path_elems, split_path);
-	ft_free(&split_path);
+	ft_free((void **)&split_path);
 }
 
 t_deque	*separate_path_and_join(const char *path, \

--- a/srcs/builtin/ft_cd/canonicalize_sep_join.c
+++ b/srcs/builtin/ft_cd/canonicalize_sep_join.c
@@ -4,6 +4,7 @@
 #include "ft_mem.h"
 #include "ft_string.h"
 
+// after end this function, remain only char **split_path. all freed inside.
 static void	add_split_path_to_path_elems(t_deque *path_elems, char **split_path)
 {
 	size_t			i;

--- a/srcs/builtin/ft_cd/canonicalize_sep_join.c
+++ b/srcs/builtin/ft_cd/canonicalize_sep_join.c
@@ -23,9 +23,7 @@ void	add_split_path_elems(t_deque *path_elems, const char *path)
 {
 	char	**split_path;
 
-	split_path = ft_split(path, PATH_DELIMITER_CHR);
-	if (!split_path)
-		ft_abort();
+	split_path = x_ft_split(path, PATH_DELIMITER_CHR);
 	add_split_path_to_path_elems(path_elems, split_path);
 	ft_free(&split_path);
 }

--- a/srcs/builtin/ft_cd/check_current_exist.c
+++ b/srcs/builtin/ft_cd/check_current_exist.c
@@ -13,17 +13,19 @@ t_result	cd_check_current_exist(const char *internal_pwd)
 	if (internal_pwd)
 		return (CONTINUE);
 	cwd = get_current_path(&tmp_err);
-	if (tmp_err == ENOENT)
-	{
-		puterr_whom_cmd_arg_msg(CHDIR, \
-								ERROR_MSG_RETRIEVE_CWD, \
-								ERROR_MSG_GETCWD, \
-								strerror(tmp_err));
-		return (FAILURE);
-	}
-	if (!cwd)
-		return (PROCESS_ERROR);
 	ft_free((void **)&cwd);
+	if (tmp_err)
+	{
+		if (tmp_err == ENOENT)
+		{
+			puterr_whom_cmd_arg_msg(CHDIR, \
+									ERROR_MSG_RETRIEVE_CWD, \
+									ERROR_MSG_GETCWD, \
+									strerror(tmp_err));
+			return (FAILURE);
+		}
+		return (PROCESS_ERROR);
+	}
 	return (SUCCESS);
 }
 
@@ -42,9 +44,11 @@ t_result	cd_check_new_path_exist(const char *arg, \
 	result = cd_exec_chdir(*new_path, &tmp_err);
 	if (result == PROCESS_ERROR || result == SUCCESS)
 		return (result);
-	cwd = get_working_directory(CMD_CD);
-	if (!cwd)
+	cwd = get_working_directory(CMD_CD, &result);
+	if (tmp_err)
 	{
+		if (result == PROCESS_ERROR)
+			return (PROCESS_ERROR);
 		tmp = *new_path;
 		*new_path = x_ft_strjoin(internal_pwd, PATH_DELIMITER_STR);
 		*new_path = extend_str(*new_path, x_ft_strdup(path));

--- a/srcs/builtin/ft_cd/check_current_exist.c
+++ b/srcs/builtin/ft_cd/check_current_exist.c
@@ -23,7 +23,7 @@ t_result	cd_check_current_exist(const char *internal_pwd)
 	}
 	if (!cwd)
 		return (PROCESS_ERROR);
-	ft_free(&cwd);
+	ft_free((void **)&cwd);
 	return (SUCCESS);
 }
 
@@ -48,10 +48,10 @@ t_result	cd_check_new_path_exist(const char *arg, \
 		tmp = *new_path;
 		*new_path = x_ft_strjoin(internal_pwd, PATH_DELIMITER_STR);
 		*new_path = extend_str(*new_path, x_ft_strdup(path));
-		ft_free(&tmp);
+		ft_free((void **)&tmp);
 		return (SUCCESS);
 	}
 	puterr_cmd_arg_msg(CMD_CD, arg, strerror(tmp_err));
-	ft_free(&cwd);
+	ft_free((void **)&cwd);
 	return (FAILURE);
 }

--- a/srcs/builtin/ft_cd/create_path_with_pwd.c
+++ b/srcs/builtin/ft_cd/create_path_with_pwd.c
@@ -41,7 +41,7 @@ static char	*get_joined_canonicalize_path(char **pre_path, \
 	char	*canonicalized_path;
 
 	canonicalized_path = cd_canonicalize_path(*pre_path, path_segment);
-	ft_free(pre_path);
+	ft_free((void **)pre_path);
 	return (canonicalized_path);
 }
 

--- a/srcs/builtin/ft_cd/ft_cd.c
+++ b/srcs/builtin/ft_cd/ft_cd.c
@@ -26,13 +26,13 @@ static t_result	change_directory_to_valid_path(const char *arg, \
 	new_path = cd_create_path_with_pwd(arg, path, internal_pwd, &result);
 	if (result == PROCESS_ERROR || result == FAILURE)
 	{
-		ft_free(&new_path);
+		ft_free((void **)&new_path);
 		return (result);
 	}
 	result = cd_check_new_path_exist(arg, &new_path, path, internal_pwd);
 	if (result == PROCESS_ERROR || result == FAILURE)
 	{
-		ft_free(&new_path);
+		ft_free((void **)&new_path);
 		return (result);
 	}
 	cd_update_pwd(new_path, context);
@@ -57,7 +57,7 @@ static t_result	change_directory(const char *arg, t_context *context)
 		return (FAILURE);
 	// ft_dprintf(2, "%s: %s, %s\n", __func__, context->internal_pwd, path);
 	result = change_directory_to_valid_path(arg, path, context);
-	ft_free(&path);
+	ft_free((void **)&path);
 	if (result == PROCESS_ERROR || result == FAILURE)
 		return (result);
 	print_mv_path_use_oldpwd_or_cdpath(is_print_path, context->internal_pwd);

--- a/srcs/builtin/ft_cd/search_cdpath.c
+++ b/srcs/builtin/ft_cd/search_cdpath.c
@@ -34,7 +34,7 @@ static char	*search_command_path(const char *arg, t_var *var)
 											(const char *const)arg, \
 											test_opendir_strict, \
 											&result);
-	ft_free(&cdpath);
+	ft_free((void **)&cdpath);
 	return (valid_path);
 }
 

--- a/srcs/builtin/ft_cd/update_pwd.c
+++ b/srcs/builtin/ft_cd/update_pwd.c
@@ -4,7 +4,7 @@
 
 static void	update_internal_pwd(char *absolute_path, t_context *context)
 {
-	ft_free(&context->internal_pwd);
+	ft_free((void **)&context->internal_pwd);
 	context->internal_pwd = absolute_path;
 }
 
@@ -15,7 +15,7 @@ static void	set_condition_old_pwd_for_update(t_var *var)
 	new_old_pwd = var_get_value(var, KEY_PWD);
 	if (!new_old_pwd)
 		var->unset(var, KEY_OLDPWD);
-	ft_free(&new_old_pwd);
+	ft_free((void **)&new_old_pwd);
 }
 
 static void	update_var_old_pwd(t_var *var)
@@ -27,7 +27,7 @@ static void	update_var_old_pwd(t_var *var)
 	new_old_pwd_attr = var_get_attribute(var, KEY_OLDPWD);
 	set_condition_old_pwd_for_update(var);
 	var->add(var, KEY_OLDPWD, new_old_pwd, new_old_pwd_attr);
-	ft_free(&new_old_pwd);
+	ft_free((void **)&new_old_pwd);
 }
 
 static void	update_var_pwd(t_context *context)

--- a/srcs/builtin/ft_cd/update_pwd.c
+++ b/srcs/builtin/ft_cd/update_pwd.c
@@ -10,7 +10,7 @@ static void	update_internal_pwd(char *absolute_path, t_context *context)
 
 static void	set_condition_old_pwd_for_update(t_var *var)
 {
-	char		*new_old_pwd;
+	char	*new_old_pwd;
 
 	new_old_pwd = var_get_value(var, KEY_PWD);
 	if (!new_old_pwd)
@@ -32,8 +32,8 @@ static void	update_var_old_pwd(t_var *var)
 
 static void	update_var_pwd(t_context *context)
 {
-	t_var		*var;
-	char		*new_pwd;
+	t_var	*var;
+	char	*new_pwd;
 
 	var = context->var;
 	new_pwd = context->internal_pwd;

--- a/srcs/builtin/ft_pwd.c
+++ b/srcs/builtin/ft_pwd.c
@@ -7,15 +7,16 @@
 // pwd op                 -> invalid op, $?=2
 static char	*get_pwd(t_context *context)
 {
-	char	*pwd;
+	char		*pwd;
+	t_result	result;
 
 	if (context->internal_pwd)
 	{
 		pwd = x_ft_strdup(context->internal_pwd);
 		return (pwd);
 	}
-	pwd = get_working_directory(CMD_PWD);
-	if (!pwd)
+	pwd = get_working_directory(CMD_PWD, &result);
+	if (result == PROCESS_ERROR || result == FAILURE)
 		return (NULL);
 	return (pwd);
 }

--- a/srcs/builtin/ft_pwd.c
+++ b/srcs/builtin/ft_pwd.c
@@ -35,6 +35,6 @@ uint8_t	ft_pwd(const char *const *argv, t_context *context)
 	if (!pwd)
 		return (EXIT_FAILURE);
 	ft_dprintf(STDOUT_FILENO, "%s\n", pwd);
-	ft_free(&pwd);
+	ft_free((void **)&pwd);
 	return (status);
 }

--- a/srcs/destroy.c
+++ b/srcs/destroy.c
@@ -6,7 +6,7 @@
 void	destroy_context(t_context context) // todo
 {
 	context.var->clear(context.var);
-	ft_free(&context.var);
-	ft_free(&context.internal_pwd);
+	ft_free((void **)&context.var);
+	ft_free((void **)&context.internal_pwd);
 	rl_clear_history();
 }

--- a/srcs/exec/exec_external_command.c
+++ b/srcs/exec/exec_external_command.c
@@ -25,7 +25,7 @@ static size_t	get_paths_len(t_var *var)
 
 	paths = var->get_value(var, KEY_PATH);
 	len = ft_strlen(paths);
-	ft_free(&paths);
+	ft_free((void **)&paths);
 	return (len);
 }
 
@@ -51,7 +51,7 @@ uint8_t	execute_external_command(char *const *argv, t_context *context)
 		puterr_cmd_msg_set_status(\
 			exec_path, strerror(errno), context, set_execve_status(errno));
 	}
-	ft_free(&exec_path);
+	ft_free((void **)&exec_path);
 	free_2d_array(&envp);
 	return (context->status);
 }

--- a/srcs/exec/expand/concat_tokens.c
+++ b/srcs/exec/expand/concat_tokens.c
@@ -46,9 +46,9 @@ static void	swap_next_token_str_and_is_quoted_arr(t_deque_node *next, \
 	t_token	*next_token;
 
 	next_token = (t_token *)next->content;
-	ft_free(&next_token->str);
+	ft_free((void **)&next_token->str);
 	next_token->str = concat_str;
-	ft_free(&next_token->is_quoted_arr);
+	ft_free((void **)&next_token->is_quoted_arr);
 	next_token->is_quoted_arr = *is_quoted_arr;
 }
 

--- a/srcs/exec/expand/expand_for_redirect.c
+++ b/srcs/exec/expand/expand_for_redirect.c
@@ -27,7 +27,7 @@ static t_result	expand_for_filename_each(t_redirect *redirect, \
 		puterr_cmd_msg(original_token, ERROR_MSG_AMBIGUOUS);
 		result = FAILURE;
 	}
-	ft_free(&original_token);
+	ft_free((void **)&original_token);
 	return (result);
 }
 

--- a/srcs/exec/expand/expand_parameter.c
+++ b/srcs/exec/expand/expand_parameter.c
@@ -15,7 +15,7 @@ static char	*strcat_after_dollar(char **str)
 	char	*new_str;
 
 	new_str = x_ft_strjoin(STR_DOLLAR, *str);
-	ft_free(str);
+	ft_free((void **)str);
 	return (new_str);
 }
 
@@ -42,7 +42,7 @@ static char	*expand_key(char **str, t_var *var)
 		return (strcat_after_dollar(&key));
 	}
 	value = var->get_value(var, key);
-	ft_free(&key);
+	ft_free((void **)&key);
 	return (value);
 }
 

--- a/srcs/exec/expand/expand_parameter.c
+++ b/srcs/exec/expand/expand_parameter.c
@@ -10,12 +10,12 @@ static char	*expand_status(char **str, t_context *context)
 	return (x_ft_itoa(context->status));
 }
 
-static char	*strcat_after_dollar(char *str)
+static char	*strcat_after_dollar(char **str)
 {
 	char	*new_str;
 
-	new_str = x_ft_strjoin(STR_DOLLAR, str);
-	ft_free(&str);
+	new_str = x_ft_strjoin(STR_DOLLAR, *str);
+	ft_free(str);
 	return (new_str);
 }
 
@@ -39,7 +39,7 @@ static char	*expand_key(char **str, t_var *var)
 	{
 		if (**str)
 			(*str)++;
-		return (strcat_after_dollar(key));
+		return (strcat_after_dollar(&key));
 	}
 	value = var->get_value(var, key);
 	ft_free(&key);

--- a/srcs/exec/expand/expand_var_in_heredoc.c
+++ b/srcs/exec/expand/expand_var_in_heredoc.c
@@ -25,8 +25,8 @@ static t_result	expand_and_transfer_heredoc(int old_fd, \
 			break ;
 		expand_line = get_expand_token_str(line, context);
 		ft_dprintf(new_fd, expand_line);
-		ft_free(&line);
-		ft_free(&expand_line);
+		ft_free((void **)&line);
+		ft_free((void **)&expand_line);
 	}
 	return (result);
 }
@@ -54,19 +54,19 @@ static t_result	clear_expand_in_heredoc(int old_fd, \
 	{
 		x_close(new_fd);
 		x_unlink(*new_filename);
-		ft_free(new_filename);
+		ft_free((void **)new_filename);
 		return (PROCESS_ERROR);
 	}
 	if (x_close(new_fd) == CLOSE_ERROR)
 	{
 		x_unlink(*new_filename);
-		ft_free(new_filename);
+		ft_free((void **)new_filename);
 		return (PROCESS_ERROR);
 	}
 	if (x_unlink(*old_filename) == UNLINK_ERROR)
 	{
 		x_unlink(*new_filename);
-		ft_free(new_filename);
+		ft_free((void **)new_filename);
 		return (PROCESS_ERROR);
 	}
 	return (SUCCESS);
@@ -77,7 +77,7 @@ static void	clear_fd_for_error(int old_fd, int new_fd, char **new_filename)
 	x_close(old_fd);
 	x_close(new_fd);
 	x_unlink(*new_filename);
-	ft_free(new_filename);
+	ft_free((void **)new_filename);
 }
 
 t_result	expand_variables_in_heredoc(t_redirect *redirect, \
@@ -100,7 +100,7 @@ t_result	expand_variables_in_heredoc(t_redirect *redirect, \
 	if (clear_expand_in_heredoc(\
 		old_fd, new_fd, &old_filename, &new_filename) == PROCESS_ERROR)
 		return (PROCESS_ERROR);
-	ft_free(&redirect->heredoc_filename);
+	ft_free((void **)&redirect->heredoc_filename);
 	redirect->heredoc_filename = new_filename;
 	return (SUCCESS);
 }

--- a/srcs/exec/expand/expansion.c
+++ b/srcs/exec/expand/expansion.c
@@ -9,7 +9,7 @@ static void	expand_token(t_token *token, t_context *context)
 	char	*expand_str;
 
 	expand_str = get_expand_token_str(token->str, context);
-	ft_free(&token->str);
+	ft_free((void **)&token->str);
 	token->str = expand_str;
 	set_is_quoted_value_to_arr(token);
 }

--- a/srcs/exec/expand/is_pattern_match.c
+++ b/srcs/exec/expand/is_pattern_match.c
@@ -36,8 +36,8 @@ static bool	is_pattern_match_and_clear_dp(bool **dp, \
 {
 	const bool	answer = (*dp)[len_target];
 
-	ft_free(dp);
-	ft_free(ndp);
+	ft_free((void **)dp);
+	ft_free((void **)ndp);
 	return (answer);
 }
 

--- a/srcs/exec/redirect_init_del.c
+++ b/srcs/exec/redirect_init_del.c
@@ -30,7 +30,7 @@ void	del_redirect(void *content)
 	if (redirect->heredoc_filename)
 	{
 		unlink(redirect->heredoc_filename);
-		ft_free(&redirect->heredoc_filename);
+		ft_free((void **)&redirect->heredoc_filename);
 	}
-	ft_free(&redirect);
+	ft_free((void **)&redirect);
 }

--- a/srcs/init.c
+++ b/srcs/init.c
@@ -19,7 +19,7 @@ static char	*set_default_internal_pwd(t_var *var)
 	int		tmp_err;
 
 	pwd_path = get_current_path(&tmp_err);
-	ft_free(&pwd_path);
+	ft_free((void **)&pwd_path);
 	if (tmp_err)
 		return (NULL);
 	return (var->get_value(var, KEY_PWD));

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -11,7 +11,9 @@ int	main(int argc, char **argv)
 	result = analyze_option(argc, argv, &is_forced_interactive, &is_rl_hook_on);
 	if (result == FAILURE)
 		return (INVALID_OPTION);
-	init_context(&context, is_forced_interactive, is_rl_hook_on);
+	result = init_context(&context, is_forced_interactive, is_rl_hook_on);
+	if (result == PROCESS_ERROR)
+		return (PROCESS_ERROR);
 	result = read_eval_print_loop(&context);
 	destroy_context(context);
 	if (result == PROCESS_ERROR)

--- a/srcs/parse/destroy_ast.c
+++ b/srcs/parse/destroy_ast.c
@@ -24,7 +24,7 @@ void	destroy_ast_node_recursive(t_ast **root)
 		deque_clear_all(&(*root)->command, del_token);
 	if ((*root)->redirect_list)
 		deque_clear_all(&(*root)->redirect_list, del_redirect);
-	ft_free(root);
+	ft_free((void **)root);
 }
 
 void	destroy_ast_tree(t_ast **root, t_result exec_result)

--- a/srcs/parse/heredoc/create_heredoc_filename.c
+++ b/srcs/parse/heredoc/create_heredoc_filename.c
@@ -12,7 +12,7 @@ static char	*create_hidden_filename(void)
 	if (!random_str)
 		return (NULL);
 	hidden_filename = x_ft_strjoin(HEREDOC_FILE_PREFIX, random_str);
-	ft_free(&random_str);
+	ft_free((void **)&random_str);
 	return (hidden_filename);
 }
 
@@ -40,7 +40,7 @@ char	*create_heredoc_filename(void)
 			return (NULL);
 		if (is_file_creatable(filename))
 			break ;
-		ft_free(&filename);
+		ft_free((void **)&filename);
 	}
 	return (filename);
 }

--- a/srcs/parse/heredoc/open_heredoc_fd.c
+++ b/srcs/parse/heredoc/open_heredoc_fd.c
@@ -24,7 +24,7 @@ t_result	create_filename_and_open_heredoc_fd(int *fd, char **filename)
 	*fd = open_file_dup_errno(*filename);
 	if (*fd == OPEN_ERROR)
 	{
-		ft_free(filename);
+		ft_free((void **)filename);
 		return (PROCESS_ERROR);
 	}
 	return (SUCCESS);

--- a/srcs/parse/heredoc/read_input_save_to_fd.c
+++ b/srcs/parse/heredoc/read_input_save_to_fd.c
@@ -61,16 +61,16 @@ t_result	read_input_save_to_fd(int fd, \
 		}
 		if (g_sig == SIGINT)
 		{
-			ft_free(&line);
+			ft_free((void **)&line);
 			set_status_and_init_sig_var(context);
 			return (BREAK);
 		}
 		if (ft_streq(line, delimiter))
 		{
-			ft_free(&line);
+			ft_free((void **)&line);
 			return (SUCCESS);
 		}
 		ft_dprintf(fd, "%s\n", line);
-		ft_free(&line);
+		ft_free((void **)&line);
 	}
 }

--- a/srcs/path/create_exec_path.c
+++ b/srcs/path/create_exec_path.c
@@ -41,11 +41,11 @@ static char	*search_command_path(const char *const command, \
 	exec_path = create_executable_path(env_path, command, result);
 	if (exec_path)
 	{
-		ft_free(&env_path);
+		ft_free((void **)&env_path);
 		return (exec_path);
 	}
 	exec_path = create_accessible_path(env_path, command, result);
-	ft_free(&env_path);
+	ft_free((void **)&env_path);
 	return (exec_path);
 }
 
@@ -76,20 +76,20 @@ char	*create_exec_path(const char *const *argv, \
 
 	exec_path = create_exec_path_inter(argv, var, paths_len, &result);
 	if (result == PROCESS_ERROR)
-		return (ft_free(&exec_path));
+		return (ft_free((void **)&exec_path));
 	if (!exec_path)
 	{
 		put_path_err_set_status(command, context, paths_len);
-		return (ft_free(&exec_path));
+		return (ft_free((void **)&exec_path));
 	}
 	is_dir = is_a_directory(exec_path, &result);
 	if (result == PROCESS_ERROR)
-		return (ft_free(&exec_path));
+		return (ft_free((void **)&exec_path));
 	if (is_dir)
 	{
 		puterr_cmd_msg_set_status(\
 			command, strerror(EISDIR), context, STATUS_IS_A_DIRECTORY);
-		return (ft_free(&exec_path));
+		return (ft_free((void **)&exec_path));
 	}
 	return (exec_path);
 }

--- a/srcs/path/create_executable_or_accessible_path.c
+++ b/srcs/path/create_executable_or_accessible_path.c
@@ -44,10 +44,10 @@ char	*create_valid_path_by_judge(char *paths, \
 	{
 		try_path = get_next_path(&paths);
 		join_path = x_ft_strjoin(try_path, arg);
-		ft_free(&try_path);
+		ft_free((void **)&try_path);
 		if (judge(join_path, result))
 			break ;
-		ft_free(&join_path);
+		ft_free((void **)&join_path);
 	}
 	return (join_path);
 }

--- a/srcs/path/create_split_src_paths.c
+++ b/srcs/path/create_split_src_paths.c
@@ -9,6 +9,6 @@ char	*create_split_src_paths(t_var *var, const char *key)
 
 	env_path = var->get_value(var, key);
 	env_path_concat_colon = x_ft_strjoin(env_path, STR_PATH_DELIMITER);
-	ft_free(&env_path);
+	ft_free((void **)&env_path);
 	return (env_path_concat_colon);
 }

--- a/srcs/path/get_next_path.c
+++ b/srcs/path/get_next_path.c
@@ -39,6 +39,6 @@ char	*get_next_path(char **path_list)
 		tail++;
 	*path_list = tail;
 	new_path = add_tail_slash_to_path(path);
-	ft_free(&path);
+	ft_free((void **)&path);
 	return (new_path);
 }

--- a/srcs/repl.c
+++ b/srcs/repl.c
@@ -51,7 +51,7 @@ t_result	read_eval_print_loop(t_context *context)
 //		ft_dprintf(2, "line:[%s]\n", line);
 		if (!line)
 			break ;
-		tokens = tokenize(line, context, &result);
+		tokens = tokenize(&line, context, &result);
 		if (result == FAILURE)
 			continue ;
 		ast = parse(&tokens, context, &result);

--- a/srcs/repl.c
+++ b/srcs/repl.c
@@ -1,5 +1,5 @@
-#include <signal.h>
 #include <readline/readline.h>
+#include <signal.h>
 #include "minishell.h"
 #include "ms_exec.h"
 #include "ms_parse.h"

--- a/srcs/signal/signal_for_heredoc.c
+++ b/srcs/signal/signal_for_heredoc.c
@@ -2,8 +2,8 @@
 #include "minishell.h"
 #include "ms_signal.h"
 #include "ms_tokenize.h"
-#include "ft_sys.h"
 #include "ft_mem.h"
+#include "ft_sys.h"
 
 extern volatile sig_atomic_t	g_sig;
 

--- a/srcs/signal/signal_for_prompt.c
+++ b/srcs/signal/signal_for_prompt.c
@@ -1,7 +1,7 @@
 #include "minishell.h"
 #include "ms_signal.h"
-#include "ft_sys.h"
 #include "ft_mem.h"
+#include "ft_sys.h"
 
 extern volatile sig_atomic_t	g_sig;
 

--- a/srcs/tokenize/del_token.c
+++ b/srcs/tokenize/del_token.c
@@ -9,9 +9,9 @@ void	del_token(void *content)
 	if (!content)
 		return ;
 	token = (t_token *)content;
-	ft_free(&token->str);
-	ft_free(&token->is_quoted_arr);
-	ft_free(&token);
+	ft_free((void **)&token->str);
+	ft_free((void **)&token->is_quoted_arr);
+	ft_free((void **)&token);
 }
 
 void	*destroy_tokens(t_deque **command, void (*del)(void *))

--- a/srcs/tokenize/remove_quote.c
+++ b/srcs/tokenize/remove_quote.c
@@ -11,7 +11,7 @@ static void	remove_quote_in_token_str_each(t_token *token)
 	char			*quote_removed;
 
 	quote_removed = x_ft_substr(token->str, 1, len - 2);
-	ft_free(&token->str);
+	ft_free((void **)&token->str);
 	token->str = quote_removed;
 }
 

--- a/srcs/tokenize/set_is_quoted_arr.c
+++ b/srcs/tokenize/set_is_quoted_arr.c
@@ -23,7 +23,7 @@ void	set_is_quoted_value_to_arr(t_token *token)
 		ft_abort();
 	is_quoted_value = get_is_quoted_value(token->quote);
 	ft_memset(is_quoted_arr, is_quoted_value, sizeof(bool) * len);
-	ft_free(&token->is_quoted_arr);
+	ft_free((void **)&token->is_quoted_arr);
 	token->is_quoted_arr = is_quoted_arr;
 }
 

--- a/srcs/tokenize/tokenize.c
+++ b/srcs/tokenize/tokenize.c
@@ -37,7 +37,7 @@ t_deque	*tokenize(char **line, t_context *context, t_result *result)
 	t_deque	*tokens;
 
 	tokens = tokenize_line(*line);
-	ft_free(line);
+	ft_free((void **)line);
 	set_token_kinds_all(tokens);
 	if (!is_valid_tokens_syntax(tokens->node))
 	{

--- a/srcs/tokenize/tokenize.c
+++ b/srcs/tokenize/tokenize.c
@@ -32,12 +32,12 @@ static bool	is_valid_tokens_syntax(t_deque_node *node)
 }
 
 // tokens != NULL
-t_deque	*tokenize(char *line, t_context *context, t_result *result)
+t_deque	*tokenize(char **line, t_context *context, t_result *result)
 {
 	t_deque	*tokens;
 
-	tokens = tokenize_line(line);
-	ft_free(&line);
+	tokens = tokenize_line(*line);
+	ft_free(line);
 	set_token_kinds_all(tokens);
 	if (!is_valid_tokens_syntax(tokens->node))
 	{

--- a/srcs/utils/extend_str.c
+++ b/srcs/utils/extend_str.c
@@ -8,7 +8,7 @@ char	*extend_str(char *left, char *right)
 
 	tmp = left;
 	left = x_ft_strjoin(tmp, right);
-	ft_free(&tmp);
-	ft_free(&right);
+	ft_free((void **)&tmp);
+	ft_free((void **)&right);
 	return (left);
 }

--- a/srcs/utils/get_random_str.c
+++ b/srcs/utils/get_random_str.c
@@ -46,7 +46,7 @@ static char	*read_random_str(const int fd, const size_t size)
 	{
 		buf[i] = read_random_alnum(fd);
 		if (!buf[i])
-			return (ft_free(&buf));
+			return (ft_free((void **)&buf));
 		i++;
 	}
 	buf[size] = CHR_NULL;

--- a/srcs/utils/get_random_str.c
+++ b/srcs/utils/get_random_str.c
@@ -20,7 +20,7 @@ static char	read_random_alnum(const int fd)
 		if (i == 0)
 		{
 			read_size = read(fd, buf, RANDOM_BUF_SIZE);
-			if (read_size == -1)
+			if (read_size == READ_ERROR)
 				return (CHR_NULL);
 		}
 		while (i < read_size && !ft_isalnum((int)buf[i]))

--- a/srcs/utils/get_working_directory.c
+++ b/srcs/utils/get_working_directory.c
@@ -11,7 +11,7 @@ static char	*extend_path(char **path, const size_t newsize)
 	new_path = (char *)x_malloc(sizeof(char) * newsize);
 	if (!new_path)
 		ft_abort();
-	ft_free(path);
+	ft_free((void **)path);
 	return (new_path);
 }
 
@@ -52,7 +52,7 @@ char	*get_working_directory(const char *for_whom)
 								ERROR_MSG_RETRIEVE_CWD, \
 								ERROR_MSG_GETCWD, \
 								strerror(tmp_err));
-		ft_free(&cwd);
+		ft_free((void **)&cwd);
 		return (NULL);
 	}
 	return (cwd);

--- a/srcs/utils/get_working_directory.c
+++ b/srcs/utils/get_working_directory.c
@@ -4,14 +4,14 @@
 #include "ft_mem.h"
 #include "ft_sys.h"
 
-static char	*extend_path(char *path, const size_t newsize)
+static char	*extend_path(char **path, const size_t newsize)
 {
 	char	*new_path;
 
 	new_path = (char *)x_malloc(sizeof(char) * newsize);
 	if (!new_path)
 		ft_abort();
-	ft_free(&path);
+	ft_free(path);
 	return (new_path);
 }
 
@@ -34,7 +34,7 @@ char	*get_current_path(int *tmp_err)
 		if (*tmp_err != ERANGE)
 			break ;
 		size *= 2;
-		path = extend_path(path, size);
+		path = extend_path(&path, size);
 	}
 	return (path);
 }

--- a/srcs/utils/x_ft_split.c
+++ b/srcs/utils/x_ft_split.c
@@ -1,0 +1,14 @@
+#include "minishell.h"
+#include "ft_string.h"
+
+char	**x_ft_split(char const *str, char c)
+{
+	char	**split_str;
+
+	if (!str)
+		return (NULL);
+	split_str = ft_split(str, c);
+	if (!split_str)
+		ft_abort();
+	return (split_str);
+}

--- a/srcs/variables/add.c
+++ b/srcs/variables/add.c
@@ -47,6 +47,7 @@ static char	*get_declare_value(t_var *var, \
 	return (dup_value);
 }
 
+// todo: fix
 // key, var_info, op, var
 // key, value, attr, op, var -> register
 static t_var_info	*var_create_var_info_for_add(t_var *var, \
@@ -59,7 +60,7 @@ static t_var_info	*var_create_var_info_for_add(t_var *var, \
 	attr = get_declare_attr(var, key, attr);
 	value = get_declare_value(var, key, value);
 	var_info = var_create_var_info_by_value_attr(value, attr);
-	ft_free(&value);
+	ft_free((void **)&value);
 	return (var_info);
 }
 

--- a/srcs/variables/add.c
+++ b/srcs/variables/add.c
@@ -47,7 +47,6 @@ static char	*get_declare_value(t_var *var, \
 	return (dup_value);
 }
 
-// todo: fix
 // key, var_info, op, var
 // key, value, attr, op, var -> register
 static t_var_info	*var_create_var_info_for_add(t_var *var, \
@@ -56,11 +55,12 @@ static t_var_info	*var_create_var_info_for_add(t_var *var, \
 													t_var_attr attr)
 {
 	t_var_info	*var_info;
+	char		*declare_value;
 
 	attr = get_declare_attr(var, key, attr);
-	value = get_declare_value(var, key, value);
-	var_info = var_create_var_info_by_value_attr(value, attr);
-	ft_free((void **)&value);
+	declare_value = get_declare_value(var, key, value);
+	var_info = var_create_var_info_by_value_attr(declare_value, attr);
+	ft_free((void **)&declare_value);
 	return (var_info);
 }
 

--- a/srcs/variables/convert.c
+++ b/srcs/variables/convert.c
@@ -5,30 +5,35 @@
 #include "ft_mem.h"
 #include "ft_sys.h"
 
+static size_t	count_key_value_pair(t_deque_node *node)
+{
+	size_t		size;
+	t_elem		*elem;
+	t_var_info	*var_info;
+
+	size = 0;
+	while (node)
+	{
+		elem = (t_elem *)node->content;
+		var_info = (t_var_info *)elem->value;
+		if (elem->key && var_info->value)
+			size++;
+		node = node->next;
+	}
+	return (size);
+}
+
 static size_t	count_envp_size(t_hash *hash)
 {
-	size_t			i;
-	t_deque_node	*node;
-	t_elem			*elem;
-	t_var_info		*var_info;
-	size_t			size;
+	size_t	size;
+	size_t	i;
 
 	size = 0;
 	i = 0;
 	while (i < hash->table_size)
 	{
 		if (hash->table[i] && hash->table[i]->size)
-		{
-			node = hash->table[i]->node;
-			while (node)
-			{
-				elem = (t_elem *)node->content;
-				var_info = (t_var_info *)elem->value;
-				if (elem->key && var_info->value)
-					size++;
-				node = node->next;
-			}
-		}
+			size += count_key_value_pair(hash->table[i]->node);
 		i++;
 	}
 	return (size);

--- a/srcs/variables/convert.c
+++ b/srcs/variables/convert.c
@@ -47,7 +47,7 @@ static char	*create_key_value_pair(const char *key, const char *value)
 	join_str = x_ft_strjoin(key, ASSIGNMENT_STR);
 	tmp = join_str;
 	join_str = x_ft_strjoin(tmp, value);
-	ft_free(&tmp);
+	ft_free((void **)&tmp);
 	return (join_str);
 }
 

--- a/srcs/variables/declare_arg.c
+++ b/srcs/variables/declare_arg.c
@@ -62,7 +62,7 @@ static t_result	var_separate_key_value_op(const char *const arg, \
 	result = validate_env_key(*key);
 	if (result == FAILURE || result == CONTINUE)
 	{
-		ft_free(key);
+		ft_free((void **)key);
 		return (result);
 	}
 	*op = get_env_op(arg, &i);
@@ -86,7 +86,7 @@ t_result	var_declare_arg(const char *const arg, t_var *var, t_var_attr attr)
 		var->add(var, key, value, attr);
 	else if (op == ENV_JOIN)
 		var->join(var, key, value, attr);
-	ft_free(&key);
-	ft_free(&value);
+	ft_free((void **)&key);
+	ft_free((void **)&value);
 	return (result);
 }

--- a/srcs/variables/join.c
+++ b/srcs/variables/join.c
@@ -29,7 +29,7 @@ static void	var_join_update_value(t_var *var, \
 	new_info = var_create_var_info_by_value_attr(joined_value, VAR_ENV);
 	hs_update_value(&key, new_info, existing_node, var->hash->del_hash_value);
 	del_var_info((void **)&var_info);
-	ft_free(&joined_value);
+	ft_free((void **)&joined_value);
 }
 
 // allocate key, value

--- a/srcs/variables/print_detail.c
+++ b/srcs/variables/print_detail.c
@@ -101,5 +101,5 @@ void	var_print_detail(t_var *var, t_var_attr attr, bool is_display_attr)
 	set_elem_pointer(elems, var->hash->table, var->hash->table_size, attr);
 	var_sort_elems_by_key(elems);
 	print_elems(elems, is_display_attr);
-	ft_free(&elems);
+	ft_free((void **)&elems);
 }

--- a/srcs/variables/set_default_environ.c
+++ b/srcs/variables/set_default_environ.c
@@ -11,8 +11,8 @@ void	del_var_info(void **var_info)
 	if (!var_info || !*var_info)
 		return ;
 	tmp_info = (t_var_info *)*var_info;
-	ft_free(&tmp_info->value);
-	ft_free(&tmp_info);
+	ft_free((void **)&tmp_info->value);
+	ft_free((void **)&tmp_info);
 	*var_info = NULL;
 }
 

--- a/srcs/variables/set_default_environ.c
+++ b/srcs/variables/set_default_environ.c
@@ -61,7 +61,17 @@ t_var	*set_default_environ(void)
 		ft_abort();
 	set_func(var);
 	set_env_default_hash(var);
-	set_default_pwd(var);
-	set_default_old_pwd(var);
+	if (set_default_pwd(var) == PROCESS_ERROR)
+	{
+		var->clear(var);
+		ft_free((void **)&var);
+		return (NULL);
+	}
+	if (set_default_old_pwd(var) == PROCESS_ERROR)
+	{
+		var->clear(var);
+		ft_free((void **)&var);
+		return (NULL);
+	}
 	return (var);
 }

--- a/srcs/variables/set_default_old_pwd.c
+++ b/srcs/variables/set_default_old_pwd.c
@@ -31,7 +31,7 @@ static void	check_and_rm_invalid_oldpwd_path(t_var *var)
 		var->unset(var, KEY_OLDPWD);
 		set_old_pwd_key_only(var);
 	}
-	ft_free(&dup_path);
+	ft_free((void **)&dup_path);
 }
 
 void	set_default_old_pwd(t_var *var)

--- a/srcs/variables/set_default_old_pwd.c
+++ b/srcs/variables/set_default_old_pwd.c
@@ -2,12 +2,11 @@
 #include "ms_var.h"
 #include "ft_mem.h"
 
-static bool	is_valid_old_pwd_path(const char *path)
+static bool	is_valid_old_pwd_path(const char *path, t_result *result)
 {
-	int			tmp_err;
-	t_result	result;
+	int	tmp_err;
 
-	return (is_valid_path(path, &tmp_err, &result));
+	return (is_valid_path(path, &tmp_err, result));
 }
 
 // key=OLDPWD
@@ -19,25 +18,35 @@ static void	set_old_pwd_key_only(t_var *var)
 
 // search path && is invalid directory
 // delete OLDPWD in hash
-static void	check_and_rm_invalid_oldpwd_path(t_var *var)
+static t_result	check_and_rm_invalid_oldpwd_path(t_var *var)
 {
-	char	*dup_path;
+	char		*dup_path;
+	t_result	result;
 
 	dup_path = var->get_value(var, KEY_OLDPWD);
 	if (!dup_path)
-		return ;
-	if (!is_valid_old_pwd_path(dup_path))
+		return (FAILURE);
+	if (!is_valid_old_pwd_path(dup_path, &result))
 	{
+		if (result == PROCESS_ERROR)
+		{
+			ft_free((void **)&dup_path);
+			return (PROCESS_ERROR);
+		}
 		var->unset(var, KEY_OLDPWD);
 		set_old_pwd_key_only(var);
 	}
 	ft_free((void **)&dup_path);
+	return (result);
 }
 
-void	set_default_old_pwd(t_var *var)
+t_result	set_default_old_pwd(t_var *var)
 {
+	t_result	result;
+
 	if (var->is_key_exist(var, KEY_OLDPWD))
-		check_and_rm_invalid_oldpwd_path(var);
+		result = check_and_rm_invalid_oldpwd_path(var);
 	else
 		set_old_pwd_key_only(var);
+	return (result);
 }

--- a/srcs/variables/set_default_pwd.c
+++ b/srcs/variables/set_default_pwd.c
@@ -10,6 +10,6 @@ void	set_default_pwd(t_var *var)
 	if (pwd_path)
 	{
 		var->add(var, KEY_PWD, pwd_path, VAR_ENV);
-		ft_free(&pwd_path);
+		ft_free((void **)&pwd_path);
 	}
 }

--- a/srcs/variables/set_default_pwd.c
+++ b/srcs/variables/set_default_pwd.c
@@ -2,14 +2,18 @@
 #include "ms_var.h"
 #include "ft_mem.h"
 
-void	set_default_pwd(t_var *var)
+t_result	set_default_pwd(t_var *var)
 {
-	char	*pwd_path;
+	char		*pwd_path;
+	t_result	result;
 
-	pwd_path = get_working_directory(SHELL_INIT);
+	pwd_path = get_working_directory(SHELL_INIT, &result);
+	if (result == PROCESS_ERROR)
+		return (PROCESS_ERROR);
 	if (pwd_path)
 	{
 		var->add(var, KEY_PWD, pwd_path, VAR_ENV);
 		ft_free((void **)&pwd_path);
 	}
+	return (SUCCESS);
 }

--- a/test/integration_test/test_function/test_output.py
+++ b/test/integration_test/test_function/test_output.py
@@ -143,7 +143,7 @@ def get_cmd_string_for_output(stdin):
 def replace_to_shell(stdin, cmd, shell_replace):
     if shell_replace:
         if cmd[0] == './minishell':
-            stdin = stdin.replace('__SHELL__', 'minishell')
+            stdin = stdin.replace('__SHELL__', 'minishell -t')
         else:
             stdin = stdin.replace("__SHELL__", "bash")
     return stdin

--- a/test/integration_test/test_function/test_valgrind.py
+++ b/test/integration_test/test_function/test_valgrind.py
@@ -4,7 +4,7 @@ from color import print_color_str, print_color_str_no_lf, RED, GREEN, YELLOW
 from test_output import replace_to_shell
 
 # ----------------------------------------------------------
-PATH_MINISHELL_LEAK = "./minishell"
+PATH_MINISHELL_LEAK = "./minishell -t"
 PATH_BASH_LEAK = "bash"
 
 # ----------------------------------------------------------

--- a/test/unit_test/get_random_str/test_get_random_str.c
+++ b/test/unit_test/get_random_str/test_get_random_str.c
@@ -45,8 +45,8 @@ static int	test(const size_t size, int test_no)
 	result ? COLOR_GREEN"OK"COLOR_RESET : COLOR_RED"NG"COLOR_RESET);
 	printf("------------------------------\n");
 
-	ft_free(&str1);
-	ft_free(&str2);
+	ft_free((void **)&str1);
+	ft_free((void **)&str2);
 	if (result)
 		return (1);
 	return (0);


### PR DESCRIPTION
- [x] (57900e6df79b46284d09a90df1aa85134d3106d2) `count_envp_size()` ネストを関数分割する
- [x] `get_token_symbol_tail()`, `get_token_paren_tail()` : const head
  -> tail が const 外しになるようで変えられなかった…
- [x] (e5ee6a5a0c79dd476348b34d41873c1efe3aa474) `read_random_alnum()` の直 -1
- [x] (59bd48b6c2c7d35aa9d9f722041167daa069cae6) `ft_free()` にポインタコピーの & になってるところは極力ダブルで貰う
- [x] (d7b21a1ea24d88db86f49e88fe60a96e5c767f93) `ft_split()` も NULL がどっちのものか分からないので wrapper がいりそう -> 既存の ft_split もそっちに変更
- [x] (6c0e11bc45745f8d8806d8d368d85306c3f0162c) `make readline` とかで readline install できると review とかで便利そう
```shell
# linux
sudo apt-get install libreadline8
sudo apt-get install libreadline-dev
# macOS
curl -fsSL https://rawgit.com/kube/42homebrew/master/install.sh | zsh
brew update && brew upgrade && brew install readline
```
- [x] (b00e0826e4aa3d036a2e6d29bd6dd16288296b2e) 一部 header を sort
- [x] (288468736d8360579cd851a81b004f45ca7aead1) `ft_cd` の中で absolute_path だけではなく relative_path も扱うことになったので、関数名 & 変数名を new_path に変更
- [x] (955e1962f61a4ae35d38c22e846ec1ce3ea71454) `var_create_var_info_for_add()` の value、おかしい…？？(見てみてください…)
const に代入できてしまっている & free できているのを修正
- [x] (22e32bd7acda6a311407f2d6385058d810c9e9b0) header の ft_free() のポインタが 1 つ少なかったのを修正、それによりキャストしてなかったところ全部 `{(void **)` キャスト追加
- [x] (a9ff5000178d8eace5385ae5b5136574cdd80e8d) `set_default_internal_pwd()`, `set_default_pwd()` の getcwd() PROCESS_ERROR handling