### PR TITLE
refactor: add include <stdio.h> for macOS readline

### DIFF
--- a/srcs/destroy.c
+++ b/srcs/destroy.c
@@ -1,3 +1,4 @@
+#include <stdio.h>
 #include <readline/readline.h>
 #include "minishell.h"
 #include "ms_var.h"

--- a/srcs/input/input.c
+++ b/srcs/input/input.c
@@ -1,3 +1,4 @@
+#include <stdio.h>
 #include <readline/readline.h>
 #include <readline/history.h>
 #include "minishell.h"

--- a/srcs/parse/heredoc/read_input_save_to_fd.c
+++ b/srcs/parse/heredoc/read_input_save_to_fd.c
@@ -1,3 +1,4 @@
+#include <stdio.h>
 #include <stdlib.h>
 #include <readline/readline.h>
 #include "minishell.h"

--- a/srcs/signal/signal_for_heredoc.c
+++ b/srcs/signal/signal_for_heredoc.c
@@ -1,3 +1,4 @@
+#include <stdio.h>
 #include <readline/readline.h>
 #include "minishell.h"
 #include "ms_signal.h"


### PR DESCRIPTION
- [x] macOS でコンパイルできるようにするため、readline の include の前に stdio.h を追加

#291 