### PR TITLE
update export test

### DIFF
--- a/test/integration_test/run_export.py
+++ b/test/integration_test/run_export.py
@@ -3,6 +3,14 @@ from test_function.test_functions import test
 PRINT_CMD = "export | grep -v ^_ | grep -v PS1 | grep -v MAKE_TERMERR | grep -v MAKE_TERMOUT"
 INIT = "unset LS_COLORS\n export PS1='bash '"
 
+def add_many(n):
+    add_cmd = "export"
+
+    for i in range(n):
+        add_cmd += " "
+        add_cmd += f"A{str(i)}=test{str(i)}"
+    return add_cmd
+
 def main():
     test_res = 0
     export_test = [
@@ -20,6 +28,9 @@ def main():
         f"{INIT} \n export A=\"a   b   c\" \n export B=\"$A\" \n echo $B \n echo \"$B\" \n{PRINT_CMD}",
         f"{INIT} \n export A=\"a   b   c\"'d   e' \n export B=\"$A\" \n echo $B \n echo \"$B\" \n{PRINT_CMD}",
         f"{INIT} \n export A=a B=b C=c D \n export A+=$A$B$noghint$C B=\"  \"aa$C\n {PRINT_CMD}",
+        f"{INIT} \n {add_many(100)}\n {PRINT_CMD} \n echo A1:$A1",
+        f"{INIT} \n {add_many(1000)}\n {PRINT_CMD} \n echo A1:$A1",
+        f"{INIT} \n {add_many(10000)}\n {PRINT_CMD} \n echo A1:$A1",
     ]
 
     test_res |= test("ft_export", export_test, False, False)

--- a/test/integration_test/run_export.py
+++ b/test/integration_test/run_export.py
@@ -1,30 +1,28 @@
 from test_function.test_functions import test
 
-# todo : add exit at last, because bash prints exit shell exit, minishell does not implement now
-PRINT_CMD = "unset PS1 && export | grep -v ^_ | grep -v SHLVL | grep -v PS1 | grep -v MAKE_TERMERR | grep -v MAKE_TERMOUT"
-PRINT_EXIT_CMD = PRINT_CMD + " && exit"
+PRINT_CMD = "export | grep -v ^_ | grep -v PS1 | grep -v MAKE_TERMERR | grep -v MAKE_TERMOUT"
+INIT = "unset LS_COLORS\n export PS1='bash '"
 
 def main():
     test_res = 0
-    echo_test = [
-        f"export A1=a1 \n {PRINT_EXIT_CMD}",
-        f"export A1=a1 A1 A1+=a2\n {PRINT_EXIT_CMD}",
-        f"export A1 A1+=a1 \n {PRINT_EXIT_CMD}",
-        f"export A1=a1 A1+= \n {PRINT_EXIT_CMD}",
-        f"export A1=a1 A1= \n {PRINT_EXIT_CMD}",
-        f"export A1=a1 \n export A1+=a2 \n {PRINT_EXIT_CMD}",
-        f"export A1=a1 \n export A1+=$A1 \n {PRINT_EXIT_CMD}",
-        f"export OK1=ok1 NG1++ OK2 OK3=ok3$OK1 OK4=$OK1 OK5=\"$OK1\" \n {PRINT_EXIT_CMD}",
-        f"export NG1~ ng*ngngngng \n {PRINT_EXIT_CMD}",
-        f"export LC_COLLATE=C && export a* \n {PRINT_EXIT_CMD}",
-        f"export LC_COLLATE=C && export * \n {PRINT_EXIT_CMD}",
-        # f"export A=\"a   b   c\" \n echo $A \n echo \"$A\" {PRINT_EXIT_CMD}", # bug PS1
-        # f"export A=\"a   b   c\" \n export B=$A     \n echo $B \n echo \"$B\" \n {PRINT_EXIT_CMD}", # word splitting
-        f"export A=\"a   b   c\" \n export B=\"$A\" \n echo $B \n echo \"$B\" \n {PRINT_EXIT_CMD}",
-        f"export A=\"a   b   c\"'d   e' \n export B=\"$A\" \n echo $B \n echo \"$B\" \n {PRINT_EXIT_CMD}",
+    export_test = [
+        f"{INIT} \n export A1=a1 \n{PRINT_CMD}",
+        f"{INIT} \n export A1=a1 A1 A1+=a \n{PRINT_CMD}",
+        f"{INIT} \n export A1 A1+=a1 \n{PRINT_CMD}",
+        f"{INIT} \n export A1=a1 A1+= \n{PRINT_CMD}",
+        f"{INIT} \n export A1=a1 A1= \n{PRINT_CMD}",
+        f"{INIT} \n export A1=a1 \n export A1+=a2 \n{PRINT_CMD}",
+        f"{INIT} \n export A1=a1 \n export A1+=$A1 \n{PRINT_CMD}",
+        f"{INIT} \n export OK1=ok1 NG1++ OK2 OK3=ok3$OK1 OK4=$OK1 OK5=\"$OK1\" \n{PRINT_CMD}",
+        f"{INIT} \n export NG1~ ng*ngngngng \n{PRINT_CMD}",
+        f"{INIT} \n export LC_COLLATE=C && export a* \n{PRINT_CMD}",
+        f"{INIT} \n export LC_COLLATE=C && export * \n{PRINT_CMD}",
+        f"{INIT} \n export A=\"a   b   c\" \n export B=\"$A\" \n echo $B \n echo \"$B\" \n{PRINT_CMD}",
+        f"{INIT} \n export A=\"a   b   c\"'d   e' \n export B=\"$A\" \n echo $B \n echo \"$B\" \n{PRINT_CMD}",
+        f"{INIT} \n export A=a B=b C=c D \n export A+=$A$B$noghint$C B=\"  \"aa$C\n {PRINT_CMD}",
     ]
 
-    test_res |= test("ft_export", echo_test, False, False)
+    test_res |= test("ft_export", export_test, False, False)
 
     return test_res
 


### PR DESCRIPTION
- export （リスト表示）の結果がバグっていた点を修正、unset PS1をやめ、PS1='bash 'のようにシンプルにするとバグ消えた...?
- exportのgrep -vからSHLVLを削除
- テストケース追加
  - `$nothing`を含むケース
  - 大量に追加されるケース（10000程度ですが...）