### PR TITLE
fix redirect with error

### DIFF
--- a/includes/ms_expansion.h
+++ b/includes/ms_expansion.h
@@ -47,7 +47,7 @@ void		sort_filenames(t_deque *tokens);
 t_result	expand_for_heredoc(t_ast *self_node, t_context *context);
 t_result	expand_variables_in_heredoc(t_redirect *redirect, \
 										t_context *context);
-t_result	expand_for_filename(t_ast *self_node, t_context *context);
+t_result	expand_for_filename_each(t_redirect *redirect, t_context *context);
 void		assign_failure_fd_to_proc_fds(int proc_fd[2]);
 
 #endif //MS_EXPANSION_H

--- a/srcs/exec/expand/expand_for_redirect.c
+++ b/srcs/exec/expand/expand_for_redirect.c
@@ -10,8 +10,7 @@ static bool	is_ambiguous_redirect(t_redirect *redirect)
 	return (redirect->tokens->size != 1);
 }
 
-static t_result	expand_for_filename_each(t_redirect *redirect, \
-											t_context *context)
+t_result	expand_for_filename_each(t_redirect *redirect, t_context *context)
 {
 	char		*original_token;
 	t_result	result;
@@ -34,28 +33,3 @@ static t_result	expand_for_filename_each(t_redirect *redirect, \
 // OK [redirect_symbol]-[file]
 // NG [redirect_symbol]-[redirect_symbol]: dropped $var
 //    [redirect_symbol]-[file]-[file]    : splitted $var
-
-// redirect_list != NULL
-// if redirect failure, proc_fd[IN/OUT] = (-1)
-t_result	expand_for_filename(t_ast *self_node, t_context *context)
-{
-	t_deque_node	*node;
-	t_redirect		*redirect;
-	t_result		result;
-
-	node = self_node->redirect_list->node;
-	while (node)
-	{
-		redirect = (t_redirect *)node->content;
-		if (redirect->kind == TOKEN_KIND_REDIRECT_HEREDOC)
-		{
-			node = node->next;
-			continue ;
-		}
-		result = expand_for_filename_each(redirect, context);
-		if (result == FAILURE || result == PROCESS_ERROR)
-			return (result);
-		node = node->next;
-	}
-	return (SUCCESS);
-}

--- a/srcs/exec/expand/expand_for_redirect.c
+++ b/srcs/exec/expand/expand_for_redirect.c
@@ -10,6 +10,9 @@ static bool	is_ambiguous_redirect(t_redirect *redirect)
 	return (redirect->tokens->size != 1);
 }
 
+// OK [redirect_symbol]-[file]
+// NG [redirect_symbol]-[redirect_symbol]: dropped $var
+//    [redirect_symbol]-[file]-[file]    : splitted $var
 t_result	expand_for_filename_each(t_redirect *redirect, t_context *context)
 {
 	char		*original_token;
@@ -29,7 +32,3 @@ t_result	expand_for_filename_each(t_redirect *redirect, t_context *context)
 	ft_free((void **)&original_token);
 	return (result);
 }
-
-// OK [redirect_symbol]-[file]
-// NG [redirect_symbol]-[redirect_symbol]: dropped $var
-//    [redirect_symbol]-[file]-[file]    : splitted $var

--- a/srcs/exec/redirects.c
+++ b/srcs/exec/redirects.c
@@ -61,7 +61,6 @@ static t_result	expand_filename_and_open_files(t_ast *self_node, \
 			return (result);
 		node = node->next;
 	}
-
 	return (SUCCESS);
 }
 

--- a/test/integration_test/run_redirects.py
+++ b/test/integration_test/run_redirects.py
@@ -1,6 +1,11 @@
 from test_function.test_functions import test
 from test_function.print_ng_case import print_ng_cases
 
+MKDIR = "rm -rf test_dir \n mkdir test_dir \n cd test_dir"
+RMDIR = "cd .. \n rm -rf test_dir"
+TOUCH_NG = "echo 'this is ng file' > ng \n chmod 000 ng"
+RM_NG = "chmod 777 ng \n rm -f ng"
+
 def main():
     test_res = 0
 
@@ -111,12 +116,75 @@ def main():
         f"cat << eof | wc \n{BIG}\neof\n",
         "<no |<no <<eof <no cat -e && <<eof2 cat -e\ntest1\n$HOME\neof\ntest2\n$HOME\neof2\n",
         ]  # todo more test
+
+    redirects_test_add = [
+        f"{MKDIR} \n ls \n export f='a   b' \n echo aaa >$f     \n ls \n {RMDIR}",
+        f"{MKDIR} \n ls \n export f='a   b' \n echo aaa >'$f'   \n ls \n {RMDIR}",
+        f"{MKDIR} \n ls \n export f='a   b' \n echo aaa >\"$f\" \n ls \n {RMDIR}",
+        f"{MKDIR} \n ls \n export f='a   b' \n echo aaa >out1>$f>out2     \n ls \n {RMDIR}",
+        f"{MKDIR} \n ls \n export f='a   b' \n echo aaa >out1>'$f'>out2   \n ls \n {RMDIR}",
+        f"{MKDIR} \n ls \n export f='a   b' \n echo aaa >out1>\"$f\">out2 \n ls \n {RMDIR}",
+
+        f"{MKDIR} \n ls \n export f='   a' \n echo aaa >$f     \n ls \n {RMDIR}",
+        f"{MKDIR} \n ls \n export f='   a' \n echo aaa >'$f'   \n ls \n {RMDIR}",
+        f"{MKDIR} \n ls \n export f='   a' \n echo aaa >\"$f\" \n ls \n {RMDIR}",
+        f"{MKDIR} \n ls \n export f='   a' \n echo aaa >out1>$f>out2     \n ls \n {RMDIR}",
+        f"{MKDIR} \n ls \n export f='   a' \n echo aaa >out1>'$f'>out2   \n ls \n {RMDIR}",
+        f"{MKDIR} \n ls \n export f='   a' \n echo aaa >out1>\"$f\">out2 \n ls \n {RMDIR}",
+
+        f"{MKDIR} \n ls \n export f='a    ' \n echo aaa >$f     \n ls \n {RMDIR}",
+        f"{MKDIR} \n ls \n export f='a    ' \n echo aaa >'$f'   \n ls \n {RMDIR}",
+        f"{MKDIR} \n ls \n export f='a    ' \n echo aaa >\"$f\" \n ls \n {RMDIR}",
+        f"{MKDIR} \n ls \n export f='a    ' \n echo aaa >out1>$f>out2     \n ls \n {RMDIR}",
+        f"{MKDIR} \n ls \n export f='a    ' \n echo aaa >out1>'$f'>out2   \n ls \n {RMDIR}",
+        f"{MKDIR} \n ls \n export f='a    ' \n echo aaa >out1>\"$f\">out2 \n ls \n {RMDIR}",
+
+        f"{MKDIR} \n ls \n export f='     ' \n echo aaa >$f     \n ls \n {RMDIR}",
+        f"{MKDIR} \n ls \n export f='     ' \n echo aaa >'$f'   \n ls \n {RMDIR}",
+        f"{MKDIR} \n ls \n export f='     ' \n echo aaa >\"$f\" \n ls \n {RMDIR}",
+        f"{MKDIR} \n ls \n export f='     ' \n echo aaa >out1>$f>out2     \n ls \n {RMDIR}",
+        f"{MKDIR} \n ls \n export f='     ' \n echo aaa >out1>'$f'>out2   \n ls \n {RMDIR}",
+        f"{MKDIR} \n ls \n export f='     ' \n echo aaa >out1>\"$f\">out2 \n ls \n {RMDIR}",
+
+
+        f"{MKDIR} \n ls \n {TOUCH_NG} \n export f='a   b' \n echo aaa >ng >$f     \n ls \n {RM_NG} \n {RMDIR}",
+        f"{MKDIR} \n ls \n {TOUCH_NG} \n export f='a   b' \n echo aaa >ng >'$f'   \n ls \n {RM_NG} \n {RMDIR}",
+        f"{MKDIR} \n ls \n {TOUCH_NG} \n export f='a   b' \n echo aaa >ng >\"$f\" \n ls \n {RM_NG} \n {RMDIR}",
+        f"{MKDIR} \n ls \n {TOUCH_NG} \n export f='a   b' \n echo aaa >ng >out1>$f>out2     \n ls \n {RM_NG} \n {RMDIR}",
+        f"{MKDIR} \n ls \n {TOUCH_NG} \n export f='a   b' \n echo aaa >ng >out1>'$f'>out2   \n ls \n {RM_NG} \n {RMDIR}",
+        f"{MKDIR} \n ls \n {TOUCH_NG} \n export f='a   b' \n echo aaa >ng >out1>\"$f\">out2 \n ls \n {RM_NG} \n {RMDIR}",
+
+        f"{MKDIR} \n ls \n {TOUCH_NG} \n export f='a   b' \n echo aaa >$f >ng    \n ls \n {RM_NG} \n {RMDIR}",
+        f"{MKDIR} \n ls \n {TOUCH_NG} \n export f='a   b' \n echo aaa >'$f'>ng   \n ls \n {RM_NG} \n {RMDIR}",
+        f"{MKDIR} \n ls \n {TOUCH_NG} \n export f='a   b' \n echo aaa >\"$f\" >ng\n ls \n {RM_NG} \n {RMDIR}",
+        f"{MKDIR} \n ls \n {TOUCH_NG} \n export f='a   b' \n echo aaa >out1>$f>ng>out2     \n ls \n {RM_NG} \n {RMDIR}",
+        f"{MKDIR} \n ls \n {TOUCH_NG} \n export f='a   b' \n echo aaa >out1>'$f'>ng>out2   \n ls \n {RM_NG} \n {RMDIR}",
+        f"{MKDIR} \n ls \n {TOUCH_NG} \n export f='a   b' \n echo aaa >out1>\"$f\">ng>out2 \n ls \n {RM_NG} \n {RMDIR}",
+
+
+        f"{MKDIR} \n ls \n {TOUCH_NG} \n export f='a   b' \n cat <ng >$f     \n ls \n {RM_NG} \n {RMDIR}",
+        f"{MKDIR} \n ls \n {TOUCH_NG} \n export f='a   b' \n cat <ng >'$f'   \n ls \n {RM_NG} \n {RMDIR}",
+        f"{MKDIR} \n ls \n {TOUCH_NG} \n export f='a   b' \n cat <ng >\"$f\" \n ls \n {RM_NG} \n {RMDIR}",
+        f"{MKDIR} \n ls \n {TOUCH_NG} \n export f='a   b' \n cat <ng >out1>$f>out2     \n ls \n {RM_NG} \n {RMDIR}",
+        f"{MKDIR} \n ls \n {TOUCH_NG} \n export f='a   b' \n cat <ng >out1>'$f'>out2   \n ls \n {RM_NG} \n {RMDIR}",
+        f"{MKDIR} \n ls \n {TOUCH_NG} \n export f='a   b' \n cat <ng >out1>\"$f\">out2 \n ls \n {RM_NG} \n {RMDIR}",
+
+        f"{MKDIR} \n ls \n {TOUCH_NG} \n export f='a   b' \n cat >$f <ng    \n ls \n {RM_NG} \n {RMDIR}",
+        f"{MKDIR} \n ls \n {TOUCH_NG} \n export f='a   b' \n cat >'$f'<ng   \n ls \n {RM_NG} \n {RMDIR}",
+        f"{MKDIR} \n ls \n {TOUCH_NG} \n export f='a   b' \n cat >\"$f\" <ng\n ls \n {RM_NG} \n {RMDIR}",
+        f"{MKDIR} \n ls \n {TOUCH_NG} \n export f='a   b' \n cat >out1>$f<ng>out2     \n ls \n {RM_NG} \n {RMDIR}",
+        f"{MKDIR} \n ls \n {TOUCH_NG} \n export f='a   b' \n cat >out1>'$f'<ng>out2   \n ls \n {RM_NG} \n {RMDIR}",
+        f"{MKDIR} \n ls \n {TOUCH_NG} \n export f='a   b' \n cat >out1>\"$f\"<ng>out2 \n ls \n {RM_NG} \n {RMDIR}",
+
+        ]
+
     test_res |= test("redirect_in_error", redirects_in_error_test, False, False)
     test_res |= test("redirect_out_error", redirects_out_error_test, False, False)
     test_res |= test("redirect_in", redirects_in_test, False, False)
     test_res |= test("redirect_out", redirects_out_test, False, False)
     test_res |= test("redirect_append", redirects_append_test, False, False)
     test_res |= test("redirect_heredoc", redirects_heredoc_test, False, False)
+    test_res |= test("redirect_additional_test", redirects_test_add, False, False)
 
     print_ng_cases(test_res)
 

--- a/test/integration_test/run_redirects.py
+++ b/test/integration_test/run_redirects.py
@@ -6,6 +6,8 @@ RMDIR = "cd .. \n rm -rf test_dir"
 TOUCH_NG = "echo 'this is ng file' > ng \n chmod 000 ng"
 RM_NG = "chmod 777 ng \n rm -f ng"
 
+TOUCH_TEST_FILES = "echo aa >test_infile1 \n echo bbb > test_infile2"
+
 def main():
     test_res = 0
 
@@ -47,56 +49,51 @@ def main():
                     "echo hello </dev/stdin | cat >/dev/stdout | cat -e"
                     ] # todo more test
 
-    RMFILES = "rm -f test_infile1 && rm -f test_infile2"
     redirects_in_test =[
-                    f"{RMFILES} \n echo aa >test_infile1 && echo bb > test_infile2 && {RMFILES}",
-                    f"cat test_infile1 && cat test_infille2 && cat <test_infile1 && {RMFILES}",
-                    f"cat test_infile1 && cat test_infille2 && cat < test_infile1 && {RMFILES}",
-                    f"cat test_infile1 && cat test_infille2 && cat <     test_infile1 && {RMFILES}",
-                    f"cat test_infile1 && cat test_infille2 && cat <test_infile1 && cat<test_infile1 && {RMFILES}",
-                    f"cat test_infile1 && cat test_infille2 && cat <test_infile1 && cat<test_infile2 && {RMFILES}",
-                    f"cat test_infile1 && cat test_infille2 && cat <test_infile1 || cat<test_infile1 && {RMFILES}",
-                    f"cat test_infile1 && cat test_infille2 && cat <test_infile1 || cat<test_infile2 && {RMFILES}",
-                    f"cat test_infile1 && cat test_infille2 && cat <test_infile1 | cat<test_infile2 && {RMFILES}",
-                    f"cat test_infile1 && cat test_infille2 && cat<test_infile1 | cat <test_infile2 && {RMFILES}",
-                    f"cat test_infile1 && cat test_infille2 && cat <test_infile1 | cat <test_infile2 | cat && {RMFILES}",
-                    f"cat test_infile1 && cat test_infille2 && cat <test_infile1 | cat <test_infile2 | cat | cat && {RMFILES}",
-                    f"cat test_infile1 && cat test_infille2 && cat <test_infile1 <test_infile2 | cat && {RMFILES}",
-                    f"cat test_infile1 && cat test_infille2 && cat <test_infile1 <test_infile1 | cat && {RMFILES}",
-                    f"cat test_infile1 && cat test_infille2 && cat <test_infile2 | cat <test_infile2 <test_infile1 | cat | cat && {RMFILES}",
-                    f"cat test_infile1 && cat test_infille2 && cat <    test_infile1<test_infile2 | cat && {RMFILES}",
-                    f"cat test_infile1 && cat test_infille2 && <test_infile1 | cat && {RMFILES}",
-                    f"cat test_infile1 && cat test_infille2 && <test_infile1 | cat | grep nothing && {RMFILES}",
-                    # "cat test_infile1 && cat test_infille2 && <test_infile1 | cat | grep a", # for actions
-                    f"cat test_infile1 && cat test_infille2 && <test_infile1 <test_infile2 | cat  && {RMFILES}",
-                    # "rm -f test_infile1 && rm -f test_infile1 && rm -f test_infile2"
-                    ]
+        f"{MKDIR} && {TOUCH_TEST_FILES} && cat test_infile1 && cat test_infille2 && cat <test_infile1 && {RMDIR}",
+        f"{MKDIR} && {TOUCH_TEST_FILES} && cat test_infile1 && cat test_infille2 && cat < test_infile1 && {RMDIR}",
+        f"{MKDIR} && {TOUCH_TEST_FILES} && cat test_infile1 && cat test_infille2 && cat <     test_infile1 && {RMDIR}",
+        f"{MKDIR} && {TOUCH_TEST_FILES} && cat test_infile1 && cat test_infille2 && cat <test_infile1 && cat<test_infile1 && {RMDIR}",
+        f"{MKDIR} && {TOUCH_TEST_FILES} && cat test_infile1 && cat test_infille2 && cat <test_infile1 && cat<test_infile2 && {RMDIR}",
+        f"{MKDIR} && {TOUCH_TEST_FILES} && cat test_infile1 && cat test_infille2 && cat <test_infile1 || cat<test_infile1 && {RMDIR}",
+        f"{MKDIR} && {TOUCH_TEST_FILES} && cat test_infile1 && cat test_infille2 && cat <test_infile1 || cat<test_infile2 && {RMDIR}",
+        f"{MKDIR} && {TOUCH_TEST_FILES} && cat test_infile1 && cat test_infille2 && cat <test_infile1 | cat<test_infile2 && {RMDIR}",
+        f"{MKDIR} && {TOUCH_TEST_FILES} && cat test_infile1 && cat test_infille2 && cat<test_infile1 | cat <test_infile2 && {RMDIR}",
+        f"{MKDIR} && {TOUCH_TEST_FILES} && cat test_infile1 && cat test_infille2 && cat <test_infile1 | cat <test_infile2 | cat && {RMDIR}",
+        f"{MKDIR} && {TOUCH_TEST_FILES} && cat test_infile1 && cat test_infille2 && cat <test_infile1 | cat <test_infile2 | cat | cat && {RMDIR}",
+        f"{MKDIR} && {TOUCH_TEST_FILES} && cat test_infile1 && cat test_infille2 && cat <test_infile1 <test_infile2 | cat && {RMDIR}",
+        f"{MKDIR} && {TOUCH_TEST_FILES} && cat test_infile1 && cat test_infille2 && cat <test_infile1 <test_infile1 | cat && {RMDIR}",
+        f"{MKDIR} && {TOUCH_TEST_FILES} && cat test_infile1 && cat test_infille2 && cat <test_infile2 | cat <test_infile2 <test_infile1 | cat | cat && {RMDIR}",
+        f"{MKDIR} && {TOUCH_TEST_FILES} && cat test_infile1 && cat test_infille2 && cat <    test_infile1<test_infile2 | cat && {RMDIR}",
+        f"{MKDIR} && {TOUCH_TEST_FILES} && cat test_infile1 && cat test_infille2 && <test_infile1 | cat && {RMDIR}",
+        f"{MKDIR} && {TOUCH_TEST_FILES} && cat test_infile1 && cat test_infille2 && <test_infile1 | cat | grep nothing && {RMDIR}",
+        # "{MKDIR} && {TOUCH_TEST_FILES} && cat test_infile1 && cat test_infille2 && <test_infile1 | cat | grep a && {RMDIR}", # for actions
+        f"{MKDIR} && {TOUCH_TEST_FILES} && cat test_infile1 && cat test_infille2 && <test_infile1 <test_infile2 | cat  && {RMDIR}",
+        ]
 
     redirects_out_test = [
-                    f"{RMFILES} \n echo aa >test_outfile1 && cat test_outfile1 && {RMFILES}",
-                    f"echo bb > test_outfile1 && cat test_outfile1 && {RMFILES}",
-                    f"echo cc >            test_outfile1 && cat test_outfile1 && {RMFILES}",
-                    f"echo dd >test_outfile1 && cat test_outfile1 && cat test_outfile1 && {RMFILES}",
-                    f"echo ee >test_outfile1 || cat test_outfile1 && cat test_outfile1 && {RMFILES}",
-                    # "echo ff >test_outfile1 | cat test_outfile1 && cat test_outfile1", # for actions
-                    f"echo gg >test_outfile1 | echo hh >test_outfile2 && cat test_outfile1 && cat test_outfile2 && {RMFILES}",
-                    f"echo ii >test_outfile1 | echo jj >test_outfile2 | cat && cat test_outfile1 && cat test_outfile2 && {RMFILES}",
-                    f"echo kk >test_outfile1 | echo ll >test_outfile2 | cat | cat && cat test_outfile1 && cat test_outfile2 && {RMFILES}",
-                    f"echo mm >test_outfile1 < test_outfile2 | cat && cat test_outfile1 && cat test_outfile2 && {RMFILES}",
-                    f"echo nn >    test_outfile1 <test_outfile2 | cat && cat test_outfile1 && cat test_outfile2 && {RMFILES}",
-                    f">test_outfile1 echo oo | cat && cat test_outfile1 && {RMFILES}",
-                    f">test_outfile1 >test_outfile2     echo pp | cat && cat test_outfile1 && cat test_outfile2 && {RMFILES}",
-                    ]
+        f"{MKDIR} && echo cc >    test_outfile1 && cat test_outfile1 && {RMDIR}",
+        f"{MKDIR} && echo dd >test_outfile1 && cat test_outfile1 && cat test_outfile1 && {RMDIR}",
+        f"{MKDIR} && echo ee >test_outfile1 || cat test_outfile1 && cat test_outfile1 && {RMDIR}",
+        # f"{MKDIR} && echo ff >test_outfile1 | cat test_outfile1 && cat test_outfile1 && {RMDIR}", # for actions
+        f"{MKDIR} && echo gg >test_outfile1 | echo hh >test_outfile2 && cat test_outfile1 && cat test_outfile2 && {RMDIR}",
+        f"{MKDIR} && echo ii >test_outfile1 | echo jj >test_outfile2 | cat && cat test_outfile1 && cat test_outfile2 && {RMDIR}",
+        f"{MKDIR} && echo kk >test_outfile1 | echo ll >test_outfile2 | cat | cat && cat test_outfile1 && cat test_outfile2 && {RMDIR}",
+        f"{MKDIR} && echo mm >test_outfile1 < test_outfile2 | cat && cat test_outfile1 && cat test_outfile2 && {RMDIR}",
+        f"{MKDIR} && echo nn >    test_outfile1 <test_outfile2 | cat && cat test_outfile1 && cat test_outfile2 && {RMDIR}",
+        f"{MKDIR} && >test_outfile1 echo oo | cat && cat test_outfile1 && {RMDIR}",
+        f"{MKDIR} && >test_outfile1 >test_outfile2     echo pp | cat && cat test_outfile1 && cat test_outfile2 && {RMDIR}",
+        ]
 
     redirects_append_test = [
-        "rm -f out \n echo a >> out \n cat out \n echo b >> out \n cat out \n rm -f out",
-        "rm -f out \n echo a >> 'ou't \n cat out \n echo b >> out \n cat out \n rm -f out",
-        "rm -f out \n export file=out\necho a >> $file \n cat out \n echo b >> out \n cat out \n rm -f out",
-        "rm -f in out \n echo in>in \n echo a >> out \n cat <in >>out \n cat out \n rm -f in out",
-        "rm -f in out1 out2 out3 nothing\n echo abc >out1>out2 <nothing >out3",
-        "rm -f in out1 out2 out3 nothing\n echo abc >out1>out2 <nothing >out3 \n ls -l \n rm -f in out1 out2 out3",
-        "rm -f in out1 out2 ng\n touch ng && chmod 000 ng\necho abc >out1>ng>out2 \n ls -l \n chmod 777 ng && rm -f in out1 out2 out3",
-                    ] # todo more test
+        f"{MKDIR} \n echo a >> out \n cat out \n echo b >> out \n cat out \n {RMDIR}",
+        f"{MKDIR} \n echo a >> 'ou't \n cat out \n echo b >> out \n cat out \n {RMDIR}",
+        f"{MKDIR} \n export file=out\necho a >> $file \n cat out \n echo b >> out \n cat out \n {RMDIR}",
+        f"{MKDIR} \n echo in>in \n echo a >> out \n cat <in >>out \n cat out \n {RMDIR}",
+        f"{MKDIR} \n echo abc >out1>out2 <nothing >out3 \n {RMDIR}",
+        f"{MKDIR} \n echo abc >out1>out2 <nothing >out3 \n ls -l \n {RMDIR}",
+        f"{MKDIR} \n touch ng && chmod 000 ng\necho abc >out1>ng>out2 \n ls -l \n chmod 777 ng \n {RMDIR}",
+        ] # todo more test
 
     BIG = "a" * 20
 


### PR DESCRIPTION
## 原因
- redirectはexpand_filename() -> open_file() の順で実行しているが、expand_filename(), open_file()でそれぞれredirectをiterate(1 ~ n番目）をしている
- redirect 1 ~ n番目全てに対しexpand(check: ambiguous)の後、1 ~ n番目をopen (check: no such file, etc...) していたため、1つでもambiguousがあるとopenが実行されていなかった

## 変更
- `expand_filename_and_open_files()`を作成しredirect 1 ~ n番目をiterateする
- i番目のexpand -> open完了後、i+1番目を実行するよう変更した
- テスト追加

<br>

```shell
minishell ls # nothing

minishell >$a
minishell: $a: ambiguous redirect

minishell >out1 >out2 >$a >out3
minishell: $a: ambiguous redirect
minishell ls
out1  out2  # dekita!

```