### PR TITLE
separate integration test file for actions

### DIFF
--- a/.github/workflows/minishell_builtin_integration_test.yml
+++ b/.github/workflows/minishell_builtin_integration_test.yml
@@ -1,0 +1,26 @@
+name: Minishell
+on:
+  push:
+    branches: [ "dev" ]
+  pull_request:
+    branches: [ "dev" ]
+
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install python3.
+        run: python3 -m pip install --upgrade pip setuptools
+
+      - name: Install valgrind
+        run: sudo apt-get -y install valgrind
+
+      - name: make
+        run: make
+
+      - name: Run all test of MINISHELL.
+        run: python3 test/integration_test/run_builtin.py

--- a/.github/workflows/minishell_builtin_integration_test.yml
+++ b/.github/workflows/minishell_builtin_integration_test.yml
@@ -1,4 +1,4 @@
-name: Minishell
+name: Builtin
 on:
   push:
     branches: [ "dev" ]

--- a/.github/workflows/minishell_error_intergation_test.yml
+++ b/.github/workflows/minishell_error_intergation_test.yml
@@ -1,4 +1,4 @@
-name: Minishell
+name: Error
 on:
   push:
     branches: [ "dev" ]

--- a/.github/workflows/minishell_error_intergation_test.yml
+++ b/.github/workflows/minishell_error_intergation_test.yml
@@ -1,0 +1,26 @@
+name: Minishell
+on:
+  push:
+    branches: [ "dev" ]
+  pull_request:
+    branches: [ "dev" ]
+
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install python3.
+        run: python3 -m pip install --upgrade pip setuptools
+
+      - name: Install valgrind
+        run: sudo apt-get -y install valgrind
+
+      - name: make
+        run: make
+
+      - name: Run all test of MINISHELL.
+        run: python3 test/integration_test/run_error.py

--- a/.github/workflows/minishell_execution_intergation_test.yml
+++ b/.github/workflows/minishell_execution_intergation_test.yml
@@ -1,4 +1,4 @@
-name: Minishell
+name: Execution
 on:
   push:
     branches: [ "dev" ]

--- a/.github/workflows/minishell_execution_intergation_test.yml
+++ b/.github/workflows/minishell_execution_intergation_test.yml
@@ -23,4 +23,4 @@ jobs:
         run: make
 
       - name: Run all test of MINISHELL.
-        run: python3 test/integration_test/run_all.py
+        run: python3 test/integration_test/run_pipe.py

--- a/.github/workflows/minishell_operator_intergation_test.yml
+++ b/.github/workflows/minishell_operator_intergation_test.yml
@@ -1,0 +1,26 @@
+name: Minishell
+on:
+  push:
+    branches: [ "dev" ]
+  pull_request:
+    branches: [ "dev" ]
+
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install python3.
+        run: python3 -m pip install --upgrade pip setuptools
+
+      - name: Install valgrind
+        run: sudo apt-get -y install valgrind
+
+      - name: make
+        run: make
+
+      - name: Run all test of MINISHELL.
+        run: python3 test/integration_test/run_op.py

--- a/.github/workflows/minishell_operator_intergation_test.yml
+++ b/.github/workflows/minishell_operator_intergation_test.yml
@@ -1,4 +1,4 @@
-name: Minishell
+name: Operator
 on:
   push:
     branches: [ "dev" ]

--- a/.github/workflows/minishell_original_intergation_test.yml
+++ b/.github/workflows/minishell_original_intergation_test.yml
@@ -1,4 +1,4 @@
-name: Minishell
+name: Minishell Original
 on:
   push:
     branches: [ "dev" ]

--- a/.github/workflows/minishell_original_intergation_test.yml
+++ b/.github/workflows/minishell_original_intergation_test.yml
@@ -1,0 +1,26 @@
+name: Minishell
+on:
+  push:
+    branches: [ "dev" ]
+  pull_request:
+    branches: [ "dev" ]
+
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install python3.
+        run: python3 -m pip install --upgrade pip setuptools
+
+      - name: Install valgrind
+        run: sudo apt-get -y install valgrind
+
+      - name: make
+        run: make
+
+      - name: Run all test of MINISHELL.
+        run: python3 test/integration_test/run_original.py

--- a/.github/workflows/minishell_path_intergation_test.yml
+++ b/.github/workflows/minishell_path_intergation_test.yml
@@ -1,4 +1,4 @@
-name: Minishell
+name: Path
 on:
   push:
     branches: [ "dev" ]

--- a/.github/workflows/minishell_path_intergation_test.yml
+++ b/.github/workflows/minishell_path_intergation_test.yml
@@ -1,0 +1,26 @@
+name: Minishell
+on:
+  push:
+    branches: [ "dev" ]
+  pull_request:
+    branches: [ "dev" ]
+
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install python3.
+        run: python3 -m pip install --upgrade pip setuptools
+
+      - name: Install valgrind
+        run: sudo apt-get -y install valgrind
+
+      - name: make
+        run: make
+
+      - name: Run all test of MINISHELL.
+        run: python3 test/integration_test/run_path.py

--- a/.github/workflows/minishell_shlvl_intergation_test.yml
+++ b/.github/workflows/minishell_shlvl_intergation_test.yml
@@ -1,4 +1,4 @@
-name: Minishell
+name: SHLVL
 on:
   push:
     branches: [ "dev" ]

--- a/.github/workflows/minishell_shlvl_intergation_test.yml
+++ b/.github/workflows/minishell_shlvl_intergation_test.yml
@@ -1,0 +1,26 @@
+name: Minishell
+on:
+  push:
+    branches: [ "dev" ]
+  pull_request:
+    branches: [ "dev" ]
+
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install python3.
+        run: python3 -m pip install --upgrade pip setuptools
+
+      - name: Install valgrind
+        run: sudo apt-get -y install valgrind
+
+      - name: make
+        run: make
+
+      - name: Run all test of MINISHELL.
+        run: python3 test/integration_test/run_shlvl.py

--- a/test/integration_test/run_all.py
+++ b/test/integration_test/run_all.py
@@ -23,25 +23,25 @@ def main():
     test_res = 0
 
     print_test_title("BUILTIN")
-    test_res |= run_builtin.main()
+    test_res |= run_builtin.run()
 
     print_test_title("EXECUTION")
-    test_res |= run_pipe.main()
+    test_res |= run_pipe.run()
 
     print_test_title("OPERATION")
-    test_res |= run_op.main()
+    test_res |= run_op.run()
 
     print_test_title("ERROR")
-    test_res |= run_error.main()
+    test_res |= run_error.run()
 
     print_test_title("ORIGINAL")
-    test_res |= run_original.main()
+    test_res |= run_original.run()
 
     print_test_title("PATH")
-    test_res |= run_path.main()
+    test_res |= run_path.run()
 
     print_test_title("OTHER")
-    test_res |= run_shlvl.main()
+    test_res |= run_shlvl.run()
 
     print_ng_cases(test_res)
 

--- a/test/integration_test/run_all.py
+++ b/test/integration_test/run_all.py
@@ -4,6 +4,7 @@ import run_pipe
 import run_op
 import run_error
 import run_original
+import run_path
 import run_shlvl
 
 BLUE = "\x1b[34m"
@@ -33,8 +34,11 @@ def main():
     print_test_title("ERROR")
     test_res |= run_error.main()
 
-    # print_test_title("ORIGINAL")
-    # test_res |= run_original.main()
+    print_test_title("ORIGINAL")
+    test_res |= run_original.main()
+
+    print_test_title("PATH")
+    test_res |= run_path.main()
 
     print_test_title("OTHER")
     test_res |= run_shlvl.main()

--- a/test/integration_test/run_builtin.py
+++ b/test/integration_test/run_builtin.py
@@ -7,7 +7,7 @@ import run_pwd
 import run_cd
 import run_declare
 
-def main():
+def run():
     test_res = 0
 
     test_res |= run_cd.main()
@@ -19,9 +19,15 @@ def main():
     test_res |= run_pwd.main()
     # test_res |= run_unset.main()
 
+    return test_res
+
+
+def main():
+    test_res = run()
+
     print_ng_cases(test_res)
 
-    return test_res
+    exit(test_res)
 
 
 if __name__ == '__main__':

--- a/test/integration_test/run_builtin.py
+++ b/test/integration_test/run_builtin.py
@@ -1,3 +1,4 @@
+from test_function.print_ng_case import print_ng_cases
 import run_echo
 import run_env
 import run_exit
@@ -13,12 +14,12 @@ def main():
     test_res |= run_declare.main()
     test_res |= run_echo.main()
     test_res |= run_env.main()
-
-    # test_res |= run_env.main()
     test_res |= run_exit.main()
     test_res |= run_export.main()
     test_res |= run_pwd.main()
     # test_res |= run_unset.main()
+
+    print_ng_cases(test_res)
 
     return test_res
 

--- a/test/integration_test/run_cd.py
+++ b/test/integration_test/run_cd.py
@@ -242,8 +242,8 @@ def main():
         f"cd dir3 {STATUS_PWD_DISPLAY}"
         f"cd .. {STATUS_PWD_DISPLAY}"
         f"cd ../dir1/dir2/dir3 {STATUS_PWD_DISPLAY}"
-        # f"cd .. {STATUS_PWD_DISPLAY}"
-        # f"cd ../../ \n rm -rf link dir1"
+        f"cd .. {STATUS_PWD_DISPLAY}"
+        f"cd ../../ \n rm -rf link dir1"
     ]
 
     commands_list += additional_test

--- a/test/integration_test/run_error.py
+++ b/test/integration_test/run_error.py
@@ -1,5 +1,5 @@
 from test_function.test_functions import test
-
+from test_function.print_ng_case import print_ng_cases
 
 def main():
     test_res = 0
@@ -47,6 +47,8 @@ def main():
     error_test = syntax_err + exec_err
 
     test_res |= test("error", error_test, False, False)
+
+    print_ng_cases(test_res)
 
     return test_res
 

--- a/test/integration_test/run_error.py
+++ b/test/integration_test/run_error.py
@@ -1,7 +1,7 @@
 from test_function.test_functions import test
 from test_function.print_ng_case import print_ng_cases
 
-def main():
+def run():
     test_res = 0
 
     syntax_err = [
@@ -48,9 +48,15 @@ def main():
 
     test_res |= test("error", error_test, False, False)
 
+    return test_res
+
+
+def main():
+    test_res = run()
+
     print_ng_cases(test_res)
 
-    return test_res
+    exit(test_res)
 
 
 if __name__ == '__main__':

--- a/test/integration_test/run_exit.py
+++ b/test/integration_test/run_exit.py
@@ -1,5 +1,7 @@
 from test_function.test_functions import test
 
+MKDIR = "rm -rf test_dir \n mkdir test_dir \n cd test_dir"
+RMDIR = "cd .. \n rm -rf test_dir"
 
 def main():
 
@@ -67,8 +69,8 @@ def main():
                  "exit \r42",
                  "exit \r\r42",
                  "exit 1 1 1 && exit 2 2 2 || exit 3",
-                 "echo a >in && <in exit 1 1 1 <in >out && rm in out  && exit 2 2 2",
-                 " exit 1 | exit 2 | exit 3 && echo a || echo b && exit 1 1 1 || echo 42 && echo hello >out"
+                 f"{MKDIR} \n echo a >in && <in exit 1 1 1 <in >out && rm in out && exit 2 2 2 \n {RMDIR}",
+                 "exit 1 | exit 2 | exit 3 && echo a || echo b && exit 1 1 1 || echo 42 && echo hello >out"
                  ]  # add more test after update tokenizer
 
     test_res |= test("ft_exit", exit_test, False, False)

--- a/test/integration_test/run_op.py
+++ b/test/integration_test/run_op.py
@@ -14,7 +14,6 @@ def main():
     test_res |= run_paren.main()
     test_res |= run_redirects.main()
     test_res |= run_expansion.main()
-    test_res |= run_path.main()
 
     print_ng_cases(test_res)
 

--- a/test/integration_test/run_op.py
+++ b/test/integration_test/run_op.py
@@ -4,9 +4,8 @@ import run_mix
 import run_paren
 import run_redirects
 import run_expansion
-import run_path
 
-def main():
+def run():
     test_res = 0
 
     test_res |= run_and_or.main()
@@ -15,9 +14,15 @@ def main():
     test_res |= run_redirects.main()
     test_res |= run_expansion.main()
 
+    return test_res
+
+
+def main():
+    test_res = run()
+
     print_ng_cases(test_res)
 
-    return test_res
+    exit(test_res)
 
 
 if __name__ == '__main__':

--- a/test/integration_test/run_original.py
+++ b/test/integration_test/run_original.py
@@ -3,10 +3,11 @@ from test_function.test_functions import test
 
 def main():
     test_res = 0
+
     different_result_from_bash_test = [
-                    "&",
+                    # "&",
                     "&&&",
-                    "& &",
+                    # "& &",
                     "a &&",
                     "echo a & &&",
                     "echo a |",
@@ -14,13 +15,13 @@ def main():
                     "~a",
                     "$-",
                     "echo $-",
-                    "$_",
+                    # "$_",
                     "echo $_",
-                    "export -a",
-                    "(())",
-                    "((()))",
+                    # "export -a",
+                    # "(())",
+                    # "((()))",
                     "(()())",
-                    "((()()))",
+                    # "((()()))",
                     "<<a () <<b",
                     "<<a ||| <<b",
                     "echo a | (e) >a && a ||",
@@ -34,11 +35,10 @@ def main():
                     "echo aa >test_outfile1 && cat test_outfile1",
                     "echo ff >test_outfile1 | cat test_outfile1 && cat test_outfile1",
                     "rm -f test_outfile1 && rm -f test_outfile1 && rm -f test_outfile2",
-                    
-                    
                     ] # todo more test
 
-    test_res |= test("different", different_result_from_bash_test, False, False)
+    # only status check
+    test_res |= test("different", different_result_from_bash_test, True, False)
 
     return test_res
 

--- a/test/integration_test/run_original.py
+++ b/test/integration_test/run_original.py
@@ -1,7 +1,8 @@
 from test_function.test_functions import test
+from test_function.print_ng_case import print_ng_cases
 
 
-def main():
+def run():
     test_res = 0
 
     different_result_from_bash_test = [
@@ -41,6 +42,14 @@ def main():
     test_res |= test("different", different_result_from_bash_test, True, False)
 
     return test_res
+
+
+def main():
+    test_res = run()
+
+    print_ng_cases(test_res)
+
+    exit(test_res)
 
 
 if __name__ == '__main__':

--- a/test/integration_test/run_path.py
+++ b/test/integration_test/run_path.py
@@ -1,4 +1,5 @@
 from test_function.test_functions import test
+from test_function.print_ng_case import print_ng_cases
 
 
 def main():
@@ -235,6 +236,8 @@ def main():
     ]
 
     test_res |= test("path", path_test, False, False)
+
+    print_ng_cases(test_res)
 
     return test_res
 

--- a/test/integration_test/run_path.py
+++ b/test/integration_test/run_path.py
@@ -2,7 +2,7 @@ from test_function.test_functions import test
 from test_function.print_ng_case import print_ng_cases
 
 
-def main():
+def run():
 
     # CMD = "echo hello>f\ncat -e f\n/bin/cat f\n/bin/rm -rf f\n"
     CMD = "echo hello>f\n/bin/cat f\n/bin/rm -rf f\n"
@@ -237,9 +237,15 @@ def main():
 
     test_res |= test("path", path_test, False, False)
 
+    return test_res
+
+
+def main():
+    test_res = run()
+
     print_ng_cases(test_res)
 
-    return test_res
+    exit(test_res)
 
 
 if __name__ == '__main__':

--- a/test/integration_test/run_pipe.py
+++ b/test/integration_test/run_pipe.py
@@ -1,8 +1,7 @@
 from test_function.test_functions import test
 from test_function.print_ng_case import print_ng_cases
 
-
-def main():
+def run():
     test_res = 0
     pipe_test = ["ls -l",
                  "echo abcde",
@@ -28,9 +27,15 @@ def main():
     test_res |= test("multi_pipe", pipe_test, False, False)
     test_res |= test("multi_pipe", pipe_error_test, False, False)
 
+    return test_res
+
+
+def main():
+    test_res = run()
+
     print_ng_cases(test_res)
 
-    return test_res
+    exit(test_res)
 
 
 if __name__ == '__main__':

--- a/test/integration_test/run_pipe.py
+++ b/test/integration_test/run_pipe.py
@@ -1,4 +1,5 @@
 from test_function.test_functions import test
+from test_function.print_ng_case import print_ng_cases
 
 
 def main():
@@ -26,6 +27,8 @@ def main():
 
     test_res |= test("multi_pipe", pipe_test, False, False)
     test_res |= test("multi_pipe", pipe_error_test, False, False)
+
+    print_ng_cases(test_res)
 
     return test_res
 

--- a/test/integration_test/run_redirects.py
+++ b/test/integration_test/run_redirects.py
@@ -1,5 +1,4 @@
 from test_function.test_functions import test
-from test_function.print_ng_case import print_ng_cases
 
 MKDIR = "rm -rf test_dir \n mkdir test_dir \n cd test_dir"
 RMDIR = "cd .. \n rm -rf test_dir"
@@ -182,8 +181,6 @@ def main():
     test_res |= test("redirect_append", redirects_append_test, False, False)
     test_res |= test("redirect_heredoc", redirects_heredoc_test, False, False)
     test_res |= test("redirect_additional_test", redirects_test_add, False, False)
-
-    print_ng_cases(test_res)
 
     return test_res
 

--- a/test/integration_test/run_shlvl.py
+++ b/test/integration_test/run_shlvl.py
@@ -5,7 +5,7 @@ from test_function.print_ng_case import print_ng_cases
 PATH_ADD = "export PATH+=:$PWD"
 
 
-def main():
+def run():
     test_res = 0
 
     lvl_list = ["0", "1", "255",
@@ -32,9 +32,15 @@ def main():
 
     test_res |= test("shlvl", shlvl_test, False, True)
 
+    return test_res
+
+
+def main():
+    test_res = run()
+
     print_ng_cases(test_res)
 
-    return test_res
+    exit(test_res)
 
 
 if __name__ == '__main__':

--- a/test/integration_test/run_shlvl.py
+++ b/test/integration_test/run_shlvl.py
@@ -1,4 +1,6 @@
 from test_function.test_functions import test
+from test_function.print_ng_case import print_ng_cases
+
 
 PATH_ADD = "export PATH+=:$PWD"
 
@@ -29,6 +31,8 @@ def main():
         shlvl_test.append(f"{PATH_ADD}\necho init:$SHLVL\nexport SHLVL={str(lvl)}\necho before:$SHLVL\n__SHELL__\necho after:$SHLVL")
 
     test_res |= test("shlvl", shlvl_test, False, True)
+
+    print_ng_cases(test_res)
 
     return test_res
 


### PR DESCRIPTION
- 1 つの yml file に job を複数書くと直列実行らしいので、並列実行したい分だけ yml file を分けた。
- 元々の run_all.py の分けをベースに分割し、run_path と run_original だけ新たに分離した。
- run_all.py は actions では使われないがそのまま残しておく
- テスト時間を見てもう少し細かく分けても良いのかもしれない…？(builtin, operator が長め -> とはいっても 12m, 7m だった早)